### PR TITLE
chore: add MIT license and bump actions/checkout to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint & test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v5

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,14 +13,14 @@ jobs:
     name: Hassfest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: home-assistant/actions/hassfest@master
 
   hacs:
     name: HACS
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: hacs/action@main
         with:
           category: integration

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Chris Bednarczyk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -53,3 +53,6 @@ device. Per-port (AC/USB/TypeC/DC) detailed power/voltage sensors are planned.
 ## Credits / disclaimer
 Independent, unofficial integration for personal use with your own hardware. Not affiliated with
 Oukitel or Quectel.
+
+## License
+Released under the [MIT License](LICENSE).


### PR DESCRIPTION
Adds an MIT `LICENSE` so the HACS validation *license* check passes (the only one of the 8 checks that was failing), and references it in the README.

Also bumps `actions/checkout` v4 → v5 in the CI and Validate workflows to clear the Node.js 20 deprecation warning.

Note: the `'str' object has no attribute 'items'` line in the HACS log is an upstream bug in the HACS action's `aiogithubapi` dependency (mis-parsing a GitHub API response); it is not a counted check and is unrelated to this repo.