### PR TITLE
fix: answer device pings to keep the local connection alive

### DIFF
--- a/REVERSE_ENGINEERING.md
+++ b/REVERSE_ENGINEERING.md
@@ -378,7 +378,13 @@ enables AES → reads & decrypts all properties live. **Proven end-to-end** agai
 | **28729** (p9) | app→dev | heartbeat/subscribe interval | TTLV `(1,num 30)(2,num 1)` |
 
 Post-login the app sends: `cmd19 (tag100=3)` (subscribe) + `cmd17` (read all) + `cmd28729` (HB);
-device then streams `cmd20` reports. To set a switch: `cmd19` with `(tag, bool)` → device acks `p6`
+device then streams `cmd20` reports.
+
+**Keepalive (issue #7):** the device sends `p7`/28727 (ping) on its own and expects `p8`/28728
+(pong, empty payload) back. Ignoring the ping makes the station tear the TCP session down after a
+few seconds, so the client must answer every ping from its read loop. The subscribe+read+heartbeat
+triple must also be re-asserted well inside the advertised 30s heartbeat window — 20s was still too
+slow on some units; 12s is stable. To set a switch: `cmd19` with `(tag, bool)` → device acks `p6`
 + reports new value via `cmd20`.
 
 **✅ WRITE VERIFIED LIVE (M3.2):** sent `cmd19 (tag44=true)` then `(tag44=false)` to the real device

--- a/custom_components/oukitel_power_station/protocol.py
+++ b/custom_components/oukitel_power_station/protocol.py
@@ -43,9 +43,10 @@ MAGIC = b"\xaa\xaa"
 
 # Keepalive: the device stops streaming unless the subscription + heartbeat are
 # re-asserted within the heartbeat window (it advertises interval=30s), so re-arm
-# every 20s. If no frame arrives within the read timeout the socket is treated as
+# every 12s -- 20s proved too slow in the field and the stream died after a few
+# reports. If no frame arrives within the read timeout the socket is treated as
 # dead and the listener exits so the coordinator reconnects.
-_REARM_INTERVAL = 20.0
+_REARM_INTERVAL = 12.0
 _READ_TIMEOUT = 90.0
 # Bound the TCP connect + handshake; without this a slow/unresponsive device
 # (or a half-open socket during a reload) blocks setup until HA's bootstrap
@@ -363,14 +364,7 @@ class OukitelConnection:
         raise OukitelAuthError("no login result (p5) received")
 
     async def _rearm(self) -> None:
-        """Re-assert HF reporting + heartbeat so the device keeps streaming."""
-        await self._send(
-            CMD_WRITE, ttlv_encode([(TAG_HF_REPORTING, "num", HF_REPORTING_LAN_WIFI)]), encrypt=True
-        )
-        await self._send(CMD_HEARTBEAT, ttlv_encode([(1, "num", 30), (2, "num", 1)]), encrypt=True)
-
-    async def subscribe_and_read(self) -> None:
-        """Enable high-frequency reporting, request a full snapshot, send heartbeat."""
+        """Re-assert HF reporting, snapshot read and heartbeat to keep the stream alive."""
         await self._send(
             CMD_WRITE, ttlv_encode([(TAG_HF_REPORTING, "num", HF_REPORTING_LAN_WIFI)]), encrypt=True
         )
@@ -378,6 +372,10 @@ class OukitelConnection:
             CMD_READ, b"".join(struct.pack(">H", t) for t in READ_TAG_IDS), encrypt=True
         )
         await self._send(CMD_HEARTBEAT, ttlv_encode([(1, "num", 30), (2, "num", 1)]), encrypt=True)
+
+    async def subscribe_and_read(self) -> None:
+        """Enable high-frequency reporting, request a full snapshot, send heartbeat."""
+        await self._rearm()
 
     async def async_set(self, tag: int, value: object, *, is_bool: bool) -> None:
         """Write a single property (cmd19)."""
@@ -435,6 +433,11 @@ class OukitelConnection:
                     frames = await asyncio.wait_for(self._read_frames(), _READ_TIMEOUT)
                 except TimeoutError as err:
                     raise OukitelError("no data within read timeout") from err
+                # The device pings us and drops the session if it is not answered.
+                for _pid, cmd, _payload in frames:
+                    if cmd == CMD_PING:
+                        _LOGGER.debug("ping received; sending pong")
+                        await self._send(CMD_PONG)
                 self._dispatch(frames)
         except asyncio.CancelledError:
             raise

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -6,7 +6,9 @@ Loads the integration's protocol/const modules without triggering the HA package
 
 from __future__ import annotations
 
+import asyncio
 import base64
+import contextlib
 import importlib.util
 import pathlib
 import struct
@@ -52,6 +54,58 @@ def check(name: str, cond: bool) -> None:
     assert cond, f"FAIL: {name}"
     _passed += 1
     print(f"  ok  {name}")
+
+
+class _FakeWriter:
+    """Minimal StreamWriter stand-in that records the frames written to it."""
+
+    def __init__(self) -> None:
+        self.sent: list[bytes] = []
+
+    def write(self, data: bytes) -> None:
+        self.sent.append(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        return None
+
+
+class _FakeReader:
+    """Yields the queued chunks once, then blocks forever."""
+
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = list(chunks)
+
+    async def read(self, _n: int) -> bytes:
+        if self._chunks:
+            return self._chunks.pop(0)
+        await asyncio.Event().wait()
+        return b""
+
+
+def _ping_gets_pong() -> bool:
+    """listen() must reply CMD_PONG when the device sends CMD_PING."""
+
+    async def run() -> bool:
+        conn = proto.OukitelConnection("127.0.0.1", AUTH_KEY)
+        writer = _FakeWriter()
+        conn._writer = writer
+        conn._reader = _FakeReader([proto.build_frame(7, const.CMD_PING, b"")])
+        conn._iv = NONCE.encode()
+        task = asyncio.create_task(conn.listen())
+        for _ in range(50):  # let the read loop run without depending on wall time
+            await asyncio.sleep(0)
+            if writer.sent:
+                break
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        cmds = [proto.FrameAssembler().feed(frame)[0][1] for frame in writer.sent]
+        return cmds == [const.CMD_PONG]
+
+    return asyncio.run(run())
 
 
 def main() -> None:
@@ -122,6 +176,10 @@ def main() -> None:
     )
     dec_struct = proto.ttlv_decode(struct_blob)
     check("struct tag8 nested sub-tags", dec_struct.get(8) == {2: 5, 7: 20})
+
+    # 11) the device's ping (p7) is answered with a pong (p8) from the read loop,
+    #     otherwise the station drops the session after a few seconds.
+    check("ping is answered with pong", _ping_gets_pong())
 
     print(f"\nALL PASSED ({_passed} checks)")
 


### PR DESCRIPTION
Fixes #7 — entities go `unavailable` after a few seconds/minutes even though the station is still online on WiFi and reachable from the WonderFree app.

## Cause
The station sends `p7` (28727) pings over the local TCP 6607 session and expects a `p8` (28728) pong. The read loop decoded those frames but never replied, so the device tore the session down shortly after the handshake. Any re-arm (or a config reload, e.g. toggling the cloud-poll option) revived it briefly, which matches the reports in the issue.

## Changes
- `listen()` now answers every `CMD_PING` with `CMD_PONG`.
- `_REARM_INTERVAL` 20s → 12s; 20s was still too slow on some units against the advertised 30s heartbeat window.
- `_rearm()` also sends the `cmd17` snapshot read, so a missed report cannot leave state stale. `subscribe_and_read()` now just delegates to it (they were duplicates).
- Documented the ping/pong requirement in `REVERSE_ENGINEERING.md`.

## Tests
Added an offline test that drives `listen()` with a fake reader/writer and asserts a `p7` in yields exactly one `p8` out. Verified it fails without the fix. `ruff check`/`ruff format --check` clean, `pytest` green (15 passed).

Thanks to @xGreenPandax for diagnosing this in the issue thread.