### PR TITLE
fix: stop transport errors escaping the cloud and local paths

### DIFF
--- a/custom_components/oukitel_power_station/cloud.py
+++ b/custom_components/oukitel_power_station/cloud.py
@@ -11,8 +11,10 @@ import base64
 import hashlib
 import logging
 import secrets
-from typing import TYPE_CHECKING, Any
+from typing import Any
 import uuid
+
+import aiohttp
 
 from .const import (
     PATH_BUSINESS_ATTRS,
@@ -23,10 +25,13 @@ from .const import (
 )
 from .protocol import aes_encrypt
 
-if TYPE_CHECKING:
-    from aiohttp import ClientSession
-
 _LOGGER = logging.getLogger(__name__)
+
+# Every cloud call sits on a path that must not stall Home Assistant: setup, the authKey
+# re-fetch, and the opt-in poll (which runs inside the coordinator update). aiohttp has no
+# default timeout, so a firewalled/black-holed route would hang the request -- and with it
+# the update loop -- until the OS gave up. See issue #6.
+_HTTP_TIMEOUT = aiohttp.ClientTimeout(total=20, connect=10)
 
 _ALPHANUM = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
@@ -74,7 +79,7 @@ def build_login_fields(
 class OukitelCloud:
     """Minimal async client for the endpoints we need."""
 
-    def __init__(self, session: ClientSession, region: str) -> None:
+    def __init__(self, session: aiohttp.ClientSession, region: str) -> None:
         if region not in REGIONS:
             raise OukitelCloudError(f"unknown region: {region}")
         self._session = session
@@ -132,16 +137,31 @@ class OukitelCloud:
 
     # --- http helpers ---
     async def _post_form(self, path: str, fields: dict[str, str]) -> dict[str, Any]:
-        async with self._session.post(
-            self.base + path, data=fields, headers=_headers(self._token)
-        ) as resp:
-            return await self._parse(resp)
+        return await self._request("POST", path, data=fields)
 
     async def _get(self, path: str, params: dict[str, str]) -> dict[str, Any]:
-        async with self._session.get(
-            self.base + path, params=params, headers=_headers(self._token)
-        ) as resp:
-            return await self._parse(resp)
+        return await self._request("GET", path, params=params)
+
+    async def _request(self, method: str, path: str, **kwargs: Any) -> dict[str, Any]:
+        """Perform one bounded request, mapping transport failures to OukitelCloudError.
+
+        Callers (config flow, authKey re-fetch, cloud poll) only handle OukitelCloudError,
+        so a raw aiohttp/timeout error escaping here would break the coordinator instead of
+        being retried on the next cycle.
+        """
+        try:
+            async with self._session.request(
+                method,
+                self.base + path,
+                headers=_headers(self._token),
+                timeout=_HTTP_TIMEOUT,
+                **kwargs,
+            ) as resp:
+                return await self._parse(resp)
+        except TimeoutError as err:
+            raise OukitelCloudError(f"timed out after {_HTTP_TIMEOUT.total}s: {path}") from err
+        except aiohttp.ClientError as err:
+            raise OukitelCloudError(f"request failed: {err}") from err
 
     @staticmethod
     async def _parse(resp: Any) -> dict[str, Any]:

--- a/custom_components/oukitel_power_station/protocol.py
+++ b/custom_components/oukitel_power_station/protocol.py
@@ -52,6 +52,8 @@ _READ_TIMEOUT = 90.0
 # (or a half-open socket during a reload) blocks setup until HA's bootstrap
 # timeout, stalling the whole instance.
 _CONNECT_TIMEOUT = 15.0
+# Tearing down a socket must never outlive a reconnect attempt.
+_CLOSE_TIMEOUT = 5.0
 
 
 class OukitelError(Exception):
@@ -306,13 +308,19 @@ class OukitelConnection:
             assert self._iv is not None
             payload = aes_encrypt(self._key, self._iv, payload)
         pid = self._next_pid()
-        self._writer.write(build_frame(pid, cmd, payload))
-        await self._writer.drain()
+        try:
+            self._writer.write(build_frame(pid, cmd, payload))
+            await self._writer.drain()
+        except OSError as err:  # reset/broken pipe: report as ours so callers reconnect
+            raise OukitelError(f"send failed: {err}") from err
         return pid
 
     async def _read_frames(self) -> list[tuple[int, int, bytes]]:
         assert self._reader is not None
-        data = await self._reader.read(4096)
+        try:
+            data = await self._reader.read(4096)
+        except OSError as err:
+            raise OukitelError(f"read failed: {err}") from err
         if not data:
             raise OukitelError("connection closed by peer")
         return self._assembler.feed(data)
@@ -328,6 +336,12 @@ class OukitelConnection:
         except OukitelError:
             await self.close()
             raise
+        except OSError as err:
+            # e.g. EHOSTUNREACH after the station moved to another IP or dropped off
+            # WiFi. Must surface as OukitelError, otherwise it escapes the coordinator
+            # and its rediscovery/retry path never runs. See issue #6.
+            await self.close()
+            raise OukitelError(f"cannot reach {self._host}:{self._port}: {err}") from err
 
     async def _open_and_handshake(self) -> None:
         _LOGGER.debug("connecting to %s:%s", self._host, self._port)
@@ -453,6 +467,8 @@ class OukitelConnection:
     async def close(self) -> None:
         if self._writer is not None:
             self._writer.close()
+            # wait_closed() can block indefinitely against a peer that stopped reading,
+            # which would wedge the very path that recovers the connection.
             with contextlib.suppress(Exception):
-                await self._writer.wait_closed()
+                await asyncio.wait_for(self._writer.wait_closed(), _CLOSE_TIMEOUT)
         self._reader = self._writer = None

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 ruff>=0.6
 pytest>=8
 cryptography>=42        # used by protocol.py (also bundled in Home Assistant)
+aiohttp>=3.9            # cloud.py HTTP client (also bundled in Home Assistant)

--- a/tests/test_cloud.py
+++ b/tests/test_cloud.py
@@ -7,12 +7,16 @@ Run:  python3 tests/test_cloud.py
 
 from __future__ import annotations
 
+import asyncio
 import base64
+import contextlib
 import hashlib
 import importlib.util
 import pathlib
 import sys
 import types
+
+import aiohttp
 
 BASE = pathlib.Path(__file__).resolve().parents[1] / "custom_components" / "oukitel_power_station"
 _pkg = types.ModuleType("ouk")
@@ -48,6 +52,47 @@ def check(name: str, cond: bool) -> None:
     print(f"  ok  {name}")
 
 
+class _FakeResponse:
+    status = 200
+
+    async def json(self, content_type: object = None) -> dict:
+        return {"code": 200, "data": {}}
+
+
+class _FakeSession:
+    """Records request kwargs; optionally raises instead of responding."""
+
+    def __init__(self, raises: BaseException | None = None) -> None:
+        self.raises = raises
+        self.kwargs: dict = {}
+
+    def request(self, _method: str, _url: str, **kwargs):
+        self.kwargs = kwargs
+        raises = self.raises
+
+        @contextlib.asynccontextmanager
+        async def _cm():
+            if raises is not None:
+                raise raises
+            yield _FakeResponse()
+
+        return _cm()
+
+
+def _request_with(session) -> object:
+    """Run one OukitelCloud request against a fake session; return the raised error or None."""
+
+    async def run():
+        client = cloud.OukitelCloud(session, "EU")
+        try:
+            await client._get("/x", {})
+        except BaseException as err:  # the test inspects whatever escapes
+            return err
+        return None
+
+    return asyncio.run(run())
+
+
 def main() -> None:
     print("cloud login crypto parity tests")
     email = "user@example.com"
@@ -74,6 +119,20 @@ def main() -> None:
     check("fields keys", set(fields) == {"pwd", "email", "random", "userDomain", "signature"})
     check("userDomain set", fields["userDomain"] == USER_DOMAIN)
     check("random preserved", fields["random"] == RANDOM)
+
+    # 5) every request is bounded (issue #6: a black-holed route must not hang the
+    #    coordinator) and transport failures surface as OukitelCloudError, which is the
+    #    only cloud exception the config flow and coordinator handle.
+    ok_session = _FakeSession()
+    check("plain request succeeds", _request_with(ok_session) is None)
+    timeout = ok_session.kwargs.get("timeout")
+    check("request passes a ClientTimeout", isinstance(timeout, aiohttp.ClientTimeout))
+    check("timeout total is bounded", 0 < (timeout.total or 0) <= 60)
+
+    conn_err = _request_with(_FakeSession(aiohttp.ClientConnectionError("no route")))
+    check("ClientError -> OukitelCloudError", isinstance(conn_err, cloud.OukitelCloudError))
+    to_err = _request_with(_FakeSession(TimeoutError()))
+    check("TimeoutError -> OukitelCloudError", isinstance(to_err, cloud.OukitelCloudError))
 
     print(f"\nALL PASSED ({_passed} checks)")
 

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -11,6 +11,7 @@ import base64
 import contextlib
 import importlib.util
 import pathlib
+import socket
 import struct
 import sys
 import types
@@ -108,6 +109,24 @@ def _ping_gets_pong() -> bool:
     return asyncio.run(run())
 
 
+def _connect_refused_error() -> object:
+    """connect() to a dead port must raise OukitelError, never a bare OSError."""
+
+    async def run() -> object:
+        sock = socket.socket()
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+        sock.close()  # nothing listening -> refused/unreachable
+        conn = proto.OukitelConnection("127.0.0.1", AUTH_KEY, port=port)
+        try:
+            await conn.connect()
+        except BaseException as err:  # the test inspects whatever escapes
+            return err
+        return None
+
+    return asyncio.run(run())
+
+
 def main() -> None:
     print("protocol offline tests")
 
@@ -180,6 +199,12 @@ def main() -> None:
     # 11) the device's ping (p7) is answered with a pong (p8) from the read loop,
     #     otherwise the station drops the session after a few seconds.
     check("ping is answered with pong", _ping_gets_pong())
+
+    # 12) a refused/unreachable TCP connect surfaces as OukitelError. A bare OSError
+    #     escapes the coordinator entirely and skips its IP-rediscovery path (issue #6).
+    err = _connect_refused_error()
+    check("connect failure is OukitelError", isinstance(err, proto.OukitelError))
+    check("connect failure is not a bare OSError", not isinstance(err, OSError))
 
     print(f"\nALL PASSED ({_passed} checks)")
 


### PR DESCRIPTION
Refs #6. Two related failures where a transport error escapes the code that is supposed to handle it, so the integration stops updating instead of retrying.

## 1. Local socket errors escape as bare `OSError`

From a real log on 0.3.1:

```
Unexpected error fetching oukitel_power_station <dk> data
  File "custom_components/oukitel_power_station/coordinator.py", line 178, in _async_update_data
  File "custom_components/oukitel_power_station/protocol.py", line 334, in _open_and_handshake
OSError: [Errno 113] Connect call failed ('192.168.60.54', 6607)
```

`connect()` caught `TimeoutError` and `OukitelError` but not `OSError`, so a failed TCP connect sailed past `_ensure_connected()`, past `_async_update_data()`, and into Home Assistant's generic catch-all ("Unexpected error fetching" is HA's `except Exception`).

The damaging part is not the log line: `_ensure_connected()`'s `except OukitelError` branch is what calls `async_discover()` to find the station at a new IP and rewrite the config entry. EHOSTUNREACH is precisely the case that branch exists for — station moved address or dropped off WiFi — and it never ran, so HA kept retrying a stale IP indefinitely. `async_set_value()` shares the path, so a switch press raised a raw `OSError` at the service call.

- `connect()` now translates `OSError` to `OukitelError`, so rediscovery and retry engage.
- Same translation in `_send()` and `_read_frames()`, which could leak `ConnectionResetError` out of `async_read_all()` the same way.
- `close()` bounds `wait_closed()` (5s); against a peer that has stopped reading it can block indefinitely, wedging the reconnect it is part of.

## 2. Cloud requests were unbounded

`cloud.py` used the shared aiohttp session with **no timeout**, and aiohttp applies no default. Three paths were exposed: config-flow login, `_refetch_auth_key()`, and `_poll_cloud_if_due()` — the last is awaited inside `_async_update_data`, and HA's `DataUpdateCoordinator` cancels the next scheduled poll *before* awaiting the update method and only reschedules in its `finally`. So one hung request stops the coordinator permanently.

Both helpers now go through one `_request()` with `ClientTimeout(total=20, connect=10)`, and `TimeoutError` / `aiohttp.ClientError` are translated to `OukitelCloudError` — the only cloud exception the config flow and coordinator handle. Previously a raw `ClientError` escaped `_poll_cloud_if_due()`'s handlers despite its "failures are swallowed" contract.

`aiohttp` is imported for real rather than under `TYPE_CHECKING`, and added to `requirements-dev.txt` so the offline tests still run standalone.

## Tests

Offline checks in both suites: a refused TCP connect surfaces as `OukitelError` and not a bare `OSError`; cloud requests pass a bounded `ClientTimeout`; `ClientError` and `TimeoutError` come back as `OukitelCloudError`. Each was verified to fail with its corresponding change reverted. `ruff check`/`format --check` clean, `pytest` green.

## Scope

Part 1 is confirmed against a real traceback. Part 2 is a real hang mechanism but is **not** confirmed to be the reporter's original freeze — those requests originate from the HA host, not the station, so a rule blocking only the Oukitel would not hit them. Leaving #6 open pending that detail.