### PR TITLE
feat: product manifest layer (TSL-driven entities foundation)

### DIFF
--- a/custom_components/oukitel_power_station/product.py
+++ b/custom_components/oukitel_power_station/product.py
@@ -1,0 +1,194 @@
+"""Product capabilities exposed by a WonderFree power station.
+
+The manifest is the ONLY place model knowledge lives. Platforms never ask
+"is this a P1500?" — they ask the manifest "does this tag (or struct subtag)
+exist on this product?" and the coordinator asks it for the read list and
+the cloud shadow key map. Adding a new model = adding its productTSL
+snapshot under ``tsl/`` (and, when needed, a curated override entry).
+
+Sources of truth, in resolver priority order:
+
+1. **snapshot** — the vendor TSL data captured at config-entry setup and stored
+   in the entry data (survives cloud outages and TSL drift);
+2. **bundled** — a snapshot shipped with the integration under
+   ``custom_components/oukitel_power_station/tsl/<pk>.json`` (offline installs,
+   migration of pre-manifest entries);
+3. **cloud** — a live ``productTSL`` fetch for a product key we do not ship
+   (a new family member works on day one, before the next release).
+
+Curated overrides (``KNOWN_PRODUCTS``) are applied after resolving a source.
+They record verified firmware behaviour the TSL itself does not express —
+e.g. the P1500 pins remain_time (2) and
+remain_charging_time (3) to 5940, so those sensors are excluded there
+(verified live 2026-09-06) while the P2001E Plus reports them correctly.
+
+This module (with tsl.py) is the portable multi-model layer: pure Python,
+no Home Assistant imports.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from .const import CLOUD_ONLY_TAGS, DEFAULT_MODEL, READ_TAG_IDS
+from .tsl import parse_tsl
+
+_LOGGER = logging.getLogger(__name__)
+
+_TSL_DIR = Path(__file__).parent / "tsl"
+
+# Verified display names per product key. Used for DeviceInfo.model; a live
+# productName from userDeviceList wins when it is available.
+KNOWN_PRODUCTS: dict[str, dict[str, Any]] = {
+    "p11uve": {
+        "model": "P1500",
+        # Pinned to 5940 by this firmware (verified live) — useless sensors.
+        "excluded_tags": (2, 3),
+    },
+    "p11wN7": {
+        "model": DEFAULT_MODEL,
+        "excluded_tags": (),
+    },
+}
+
+
+@dataclass(frozen=True)
+class ProductManifest:
+    """What one product key exposes."""
+
+    product_key: str
+    model: str
+    tsl_version: str | None
+    profile_version: str | None
+    tags: dict[int, dict[str, Any]]
+    code_to_tag: dict[str, int]
+    excluded_tags: tuple[int, ...] = field(default_factory=tuple)
+
+    # --- queries the platforms/coordinator rely on ---------------------------
+    def has_tag(self, tag: int) -> bool:
+        """True when the product exposes the tag and it is not excluded."""
+        return tag in self.tags and tag not in self.excluded_tags
+
+    def has_subtag(self, tag: int, subtag: int) -> bool:
+        """True when a struct tag exists and contains the given subtag."""
+        if not self.has_tag(tag):
+            return False
+        return subtag in (self.tags[tag].get("struct") or {})
+
+    def tag_spec(self, tag: int) -> dict[str, Any]:
+        """Return the parsed TSL property for a tag (empty dict if absent)."""
+        return self.tags.get(tag, {})
+
+    def enum_options(self, tag: int) -> dict[int, str]:
+        """Return the {raw value: label} map for an ENUM tag (may be empty)."""
+        return dict(self.tags.get(tag, {}).get("enum") or {})
+
+    def read_tag_ids(self) -> tuple[int, ...]:
+        """The cmd17 snapshot read list: every manifest tag + hf reporting."""
+        vendor_order = tuple(tag for tag in READ_TAG_IDS if tag in self.tags or tag == 100)
+        extra_tags = tuple(sorted(set(self.tags) - set(vendor_order)))
+        return vendor_order + extra_tags
+
+    def cloud_only_tags(self) -> tuple[int, ...]:
+        """Cloud-only tags that exist on this product (LAN never reports)."""
+        return tuple(t for t in CLOUD_ONLY_TAGS if t in self.tags)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise for config-entry storage (snapshot; JSON-safe)."""
+        return {
+            "product_key": self.product_key,
+            "tsl_version": self.tsl_version,
+            "profile_version": self.profile_version,
+            "tags": {str(t): spec for t, spec in self.tags.items()},
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProductManifest:
+        """Rebuild from a config-entry snapshot."""
+        tags = {
+            int(tag): _restore_json_keys(spec) for tag, spec in (data.get("tags") or {}).items()
+        }
+        product_key = str(data.get("product_key") or "")
+        return cls(
+            product_key=product_key,
+            model=product_key or "unknown",
+            tsl_version=data.get("tsl_version"),
+            profile_version=data.get("profile_version"),
+            tags=tags,
+            code_to_tag={str(spec["code"]): t for t, spec in tags.items()},
+        )
+
+
+def _restore_json_keys(spec: dict[str, Any]) -> dict[str, Any]:
+    """Restore integer keys stringified by config-entry JSON storage."""
+    restored = dict(spec)
+    if isinstance(enum := restored.get("enum"), dict):
+        restored["enum"] = {int(value): label for value, label in enum.items()}
+    if isinstance(struct := restored.get("struct"), dict):
+        restored["struct"] = {int(tag): sub_spec for tag, sub_spec in struct.items()}
+    return restored
+
+
+def build_manifest(tsl_data: dict[str, Any]) -> ProductManifest:
+    """Build a vendor-derived manifest from a raw productTSL ``data`` object."""
+    parsed = parse_tsl(tsl_data)
+    pk = str(parsed["product_key"] or "")
+    return ProductManifest(
+        product_key=pk,
+        model=pk or "unknown",
+        tsl_version=parsed["tsl_version"],
+        profile_version=parsed["profile_version"],
+        tags=parsed["tags"],
+        code_to_tag=parsed["code_to_tag"],
+    )
+
+
+def load_bundled_tsl(product_key: str) -> dict[str, Any] | None:
+    """Load a bundled productTSL snapshot, or None when we do not ship it."""
+    path = _TSL_DIR / f"{product_key}.json"
+    if not path.is_file():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as err:  # pragma: no cover
+        _LOGGER.warning("bundled TSL %s unreadable: %s", path, err)
+        return None
+
+
+def manifest_from_bundled(product_key: str) -> ProductManifest | None:
+    """Build a manifest from a bundled snapshot (None when not shipped)."""
+    tsl_data = load_bundled_tsl(product_key)
+    if tsl_data is None:
+        return None
+    return build_manifest(tsl_data)
+
+
+def resolve_manifest(
+    product_key: str,
+    snapshot: dict[str, Any] | None = None,
+    cloud_tsl: dict[str, Any] | None = None,
+) -> ProductManifest | None:
+    """Resolve a manifest: snapshot → bundled → cloud. None when all fail."""
+    manifest = None
+    if snapshot:
+        try:
+            manifest = ProductManifest.from_dict(snapshot)
+        except (KeyError, TypeError, ValueError) as err:
+            _LOGGER.debug("ignoring corrupt manifest snapshot: %s", err)
+    if manifest is None:
+        manifest = manifest_from_bundled(product_key)
+    if manifest is None and cloud_tsl:
+        manifest = build_manifest(cloud_tsl)
+    if manifest is None:
+        return None
+
+    known = KNOWN_PRODUCTS.get(manifest.product_key, {})
+    return replace(
+        manifest,
+        model=str(known.get("model") or manifest.product_key or "unknown"),
+        excluded_tags=tuple(known.get("excluded_tags") or ()),
+    )

--- a/custom_components/oukitel_power_station/tsl.py
+++ b/custom_components/oukitel_power_station/tsl.py
@@ -1,0 +1,147 @@
+"""Parse a Quectel productTSL payload into a product manifest.
+
+Pure functions, no Home Assistant imports — this module (with product.py) is
+the portable multi-model layer for consumers of the Quectel/WonderFree
+thing-model.
+
+Input shape (the ``data`` object of a ``productTSL?pk=…`` response, or one of
+the bundled snapshots under ``custom_components/oukitel_power_station/tsl/``)::
+
+    {
+      "profile": {"tslVersion": "1.2.0", "productKey": "p11uve", "version": "…"},
+      "properties": [
+        {
+          "id": 11, "code": "ac_input", "dataType": "INT", "name": "…",
+          "subType": "R", "type": "PROPERTY", "desc": "…",
+          "specs": {"unit": "W", "min": "0", "max": "65535", "step": "1"}
+                 | [{"dataType": "ENUM", "name": "50Hz", "value": "0"}, …]
+                 | [<sub-property dicts> for STRUCT],   # STRUCT: list of dicts
+        },
+        …
+      ]
+    }
+
+The TSL format is shared across the WonderFree family (verified: p11uve /
+P1500 and p11wN7 / P2001E Plus have the same shape, 20 identical tag ids).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+def parse_property(prop: dict[str, Any]) -> dict[str, Any]:
+    """Normalise one TSL property dict.
+
+    Returns a compact dict with only what the integration consumes:
+    ``id, code, data_type, name, sub_type, unit, min, max, step,
+    enum (raw value -> label), struct ({subtag id: sub-spec})``.
+    Unknown/missing fields degrade to None/empty rather than raising — the
+    cloud schema is not versioned, so a new field must never break setup.
+    """
+    specs = prop.get("specs")
+    data_type = prop.get("dataType")
+
+    unit = min_v = max_v = step = None
+    enum: dict[int, str] = {}
+    struct: dict[int, dict[str, Any]] = {}
+
+    if isinstance(specs, dict):
+        unit = specs.get("unit") or None
+        min_v = _to_number(specs.get("min"))
+        max_v = _to_number(specs.get("max"))
+        step = _to_number(specs.get("step"))
+    elif isinstance(specs, list):
+        if data_type == "STRUCT":
+            for sub in specs:
+                if not isinstance(sub, dict) or "id" not in sub:
+                    continue
+                sub_specs = sub.get("specs")
+                struct[sub["id"]] = {
+                    "code": sub.get("code"),
+                    "data_type": sub.get("dataType"),
+                    "name": sub.get("name"),
+                    "unit": (sub_specs or {}).get("unit") or None
+                    if isinstance(sub_specs, dict)
+                    else None,
+                }
+        else:
+            # ENUM entries: [{"dataType": "ENUM", "name": "50Hz", "value": "0"}]
+            for entry in specs:
+                if not isinstance(entry, dict):
+                    continue
+                raw = entry.get("value")
+                label = entry.get("name")
+                if raw is None or label is None:
+                    continue
+                value = _to_number(raw)
+                if value is not None:
+                    enum[int(value)] = str(label)
+
+    return {
+        "id": prop.get("id"),
+        "code": prop.get("code"),
+        "data_type": data_type,
+        "name": prop.get("name"),
+        "sub_type": prop.get("subType"),
+        "unit": unit,
+        "min": min_v,
+        "max": max_v,
+        "step": step,
+        "enum": enum,
+        "struct": struct,
+    }
+
+
+def parse_tsl(data: dict[str, Any]) -> dict[str, Any]:
+    """Parse a full productTSL ``data`` object into manifest dicts.
+
+    Returns::
+
+        {
+          "product_key": str,
+          "tsl_version": str | None,
+          "profile_version": str | None,
+          "tags": {tag_id: parsed property},          # int keys
+          "code_to_tag": {resource_code: tag_id},      # str -> int
+        }
+
+    Properties without a numeric id or without a code are skipped (a
+    service/action entry must never break the entity manifest).
+    """
+    profile = data.get("profile") or {}
+    tags: dict[int, dict[str, Any]] = {}
+    code_to_tag: dict[str, int] = {}
+
+    for prop in data.get("properties") or []:
+        if not isinstance(prop, dict):
+            continue
+        parsed = parse_property(prop)
+        tag = parsed.get("id")
+        code = parsed.get("code")
+        if not isinstance(tag, int) or not code:
+            continue
+        tags[tag] = parsed
+        code_to_tag[str(code)] = tag
+
+    return {
+        "product_key": profile.get("productKey"),
+        "tsl_version": profile.get("tslVersion"),
+        "profile_version": profile.get("version"),
+        "tags": tags,
+        "code_to_tag": code_to_tag,
+    }
+
+
+def _to_number(raw: Any) -> int | float | None:
+    """Coerce a TSL spec scalar (string like "65535") to int/float or None."""
+    if raw is None or raw == "":
+        return None
+    try:
+        value = float(raw)
+        if not math.isfinite(value):
+            return None
+        return int(value) if value.is_integer() else value
+    except (OverflowError, TypeError, ValueError):
+        return None

--- a/custom_components/oukitel_power_station/tsl/p11uve.json
+++ b/custom_components/oukitel_power_station/tsl/p11uve.json
@@ -1,0 +1,532 @@
+{
+ "profile": {
+  "tslVersion": "1.2.0",
+  "productKey": "p11uve",
+  "version": "20241209155030563"
+ },
+ "properties": [
+  {
+   "specs": {
+    "unit": "min",
+    "min": "0",
+    "max": "65535",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "remain_time",
+   "dataType": "INT",
+   "name": "Remaining Use Time",
+   "subType": "R",
+   "id": 2,
+   "sort": 0,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "specs": {
+      "unit": "W",
+      "min": "0",
+      "max": "65535",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "Typec1_output",
+     "dataType": "INT",
+     "name": "Type-C1 Output Power",
+     "id": 2
+    },
+    {
+     "specs": {
+      "unit": "W",
+      "min": "0",
+      "max": "65535",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "Typec2_output",
+     "dataType": "INT",
+     "name": "Type-C2 Output Power",
+     "id": 5
+    }
+   ],
+   "code": "typec_data",
+   "dataType": "STRUCT",
+   "name": "Type-C Info",
+   "subType": "RW",
+   "id": 8,
+   "sort": 1,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "specs": {
+      "unit": "W",
+      "min": "0",
+      "max": "65535",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "car1_output",
+     "dataType": "INT",
+     "name": "Car1 Output Power",
+     "id": 2
+    },
+    {
+     "specs": {
+      "unit": "V",
+      "min": "0",
+      "max": "500",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "car1_output_voltage",
+     "dataType": "INT",
+     "name": "Car1 Output Voltage",
+     "id": 3
+    },
+    {
+     "specs": {
+      "unit": "A",
+      "min": "0",
+      "max": "50",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "car1_output_current",
+     "dataType": "INT",
+     "name": "Car1 Output Current",
+     "id": 4
+    }
+   ],
+   "code": "dc_data",
+   "dataType": "STRUCT",
+   "name": "DC Info",
+   "subType": "RW",
+   "id": 9,
+   "sort": 2,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "specs": {
+      "unit": "W",
+      "min": "0",
+      "max": "65535",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "ac1_output",
+     "dataType": "INT",
+     "name": "AC1 Output Power",
+     "id": 2
+    },
+    {
+     "specs": {
+      "unit": "V",
+      "min": "0",
+      "max": "500",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "ac1_output_voltage",
+     "dataType": "INT",
+     "name": "AC1 Output Voltage",
+     "id": 3
+    }
+   ],
+   "code": "ac_data",
+   "dataType": "STRUCT",
+   "name": "AC Info",
+   "subType": "RW",
+   "id": 6,
+   "sort": 3,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "",
+    "min": "0",
+    "max": "65530",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "AC_Version",
+   "dataType": "INT",
+   "name": "Inverter Version",
+   "subType": "R",
+   "id": 31,
+   "sort": 4,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "specs": {
+      "unit": "W",
+      "min": "0",
+      "max": "65535",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "USB_QC1_output",
+     "dataType": "INT",
+     "name": "USB-A1 Output Power",
+     "id": 2
+    },
+    {
+     "specs": {
+      "unit": "W",
+      "min": "0",
+      "max": "65535",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "USB_QC2_output",
+     "dataType": "INT",
+     "name": "USB_QC2",
+     "id": 3
+    }
+   ],
+   "code": "usb_data",
+   "dataType": "STRUCT",
+   "name": "USB Info",
+   "subType": "RW",
+   "id": 7,
+   "sort": 5,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "dataType": "ENUM",
+     "name": "100V",
+     "value": "100"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "110V",
+     "value": "110"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "120V",
+     "value": "120"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "220V",
+     "value": "220"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "230V",
+     "value": "230"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "240V",
+     "value": "240"
+    }
+   ],
+   "code": "ACvoltage_Switchover",
+   "dataType": "ENUM",
+   "name": "Voltage Selection",
+   "subType": "RW",
+   "id": 28,
+   "sort": 7,
+   "type": "PROPERTY",
+   "desc": "交流电输出电压切换高低"
+  },
+  {
+   "specs": [
+    {
+     "dataType": "ENUM",
+     "name": "OFF",
+     "value": "0"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "High",
+     "value": "1"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "SOS",
+     "value": "3"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "Flash",
+     "value": "2"
+    }
+   ],
+   "code": "led_status",
+   "dataType": "ENUM",
+   "name": "LED Indicator Status",
+   "subType": "RW",
+   "id": 10,
+   "sort": 8,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "dataType": "ENUM",
+     "name": "50Hz",
+     "value": "0"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "60Hz",
+     "value": "1"
+    }
+   ],
+   "code": "Frequency_Switchover",
+   "dataType": "ENUM",
+   "name": "Frequency Selection",
+   "subType": "RW",
+   "id": 27,
+   "sort": 8,
+   "type": "PROPERTY",
+   "desc": "切换频率开关"
+  },
+  {
+   "specs": {
+    "unit": "℃",
+    "min": "-100",
+    "max": "100",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "temp",
+   "dataType": "INT",
+   "name": "Device Temperature",
+   "subType": "R",
+   "id": 14,
+   "sort": 10,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "W",
+    "min": "0",
+    "max": "65535",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "dc_input",
+   "dataType": "INT",
+   "name": "DC Input Power",
+   "subType": "R",
+   "id": 12,
+   "sort": 11,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "W",
+    "min": "0",
+    "max": "65535",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "ac_input",
+   "dataType": "INT",
+   "name": "AC Input Power",
+   "subType": "R",
+   "id": 11,
+   "sort": 12,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "W",
+    "min": "0",
+    "max": "65535",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "total_output_power",
+   "dataType": "INT",
+   "name": "Total Output Power",
+   "subType": "R",
+   "id": 5,
+   "sort": 13,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "W",
+    "min": "0",
+    "max": "65535",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "total_input_power",
+   "dataType": "INT",
+   "name": "Total Input Power",
+   "subType": "R",
+   "id": 4,
+   "sort": 14,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "min",
+    "min": "0",
+    "max": "65535",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "remain_charging_time",
+   "dataType": "INT",
+   "name": "Remaining Charge Time",
+   "subType": "R",
+   "id": 3,
+   "sort": 15,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "%",
+    "min": "0",
+    "max": "100",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "battery_percentage",
+   "dataType": "INT",
+   "name": "Battery Level",
+   "subType": "R",
+   "id": 1,
+   "sort": 16,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "",
+    "min": "0",
+    "max": "65535",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "BMS_Version",
+   "dataType": "INT",
+   "name": "BMS Version",
+   "subType": "R",
+   "id": 34,
+   "sort": 17,
+   "type": "PROPERTY",
+   "desc": "上传BMS版本号"
+  },
+  {
+   "specs": {
+    "unit": "",
+    "min": "0",
+    "max": "100",
+    "step": "1"
+   },
+   "code": "ac_charging_limit",
+   "dataType": "INT",
+   "name": "AC Fast/Slow Charge Status",
+   "subType": "RW",
+   "id": 20,
+   "sort": 18,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "dataType": "ENUM",
+     "name": "Standard Reporting",
+     "value": "0"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "LAN High-Rate Reporting",
+     "value": "1"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "Wi-Fi High-Rate Reporting",
+     "value": "2"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "LAN & Wi-Fi High-Rate Reporting",
+     "value": "3"
+    }
+   ],
+   "code": "high_frequency_reporting",
+   "dataType": "ENUM",
+   "name": "High-Rate Reporting",
+   "subType": "RW",
+   "id": 100,
+   "sort": 19,
+   "type": "PROPERTY",
+   "desc": "有局域网，面板下发1-局域面板判断是否有局域网，网高频上报值给到设备，设备开始高频上报并上报1-局域网高频，30s后设备关闭高频上报并上报0，如果面板依旧下发1-局域网高频上报给到设备，设备继续高频上报。若面板未返回值，则设备不再高频上报。面板判断是否有局域网，若没有，面板下发2-Wi-Fi高频上报值给到设备，设备开始高频上报并上报2，30s后设备关闭高频上报并上报0，如果面板依旧下发2-Wi-F"
+  },
+  {
+   "specs": [
+    {
+     "dataType": "BOOL",
+     "name": "ON",
+     "value": "true"
+    },
+    {
+     "dataType": "BOOL",
+     "name": "OFF",
+     "value": "false"
+    }
+   ],
+   "code": "ac_switch",
+   "dataType": "BOOL",
+   "name": "AC Switch",
+   "subType": "RW",
+   "id": 43,
+   "sort": 25,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "dataType": "BOOL",
+     "name": "ON",
+     "value": "true"
+    },
+    {
+     "dataType": "BOOL",
+     "name": "OFF",
+     "value": "false"
+    }
+   ],
+   "code": "dc_switch",
+   "dataType": "BOOL",
+   "name": "DC Switch",
+   "subType": "RW",
+   "id": 46,
+   "sort": 28,
+   "type": "PROPERTY",
+   "desc": ""
+  }
+ ]
+}

--- a/custom_components/oukitel_power_station/tsl/p11wN7.json
+++ b/custom_components/oukitel_power_station/tsl/p11wN7.json
@@ -1,0 +1,603 @@
+{
+ "profile": {
+  "tslVersion": "1.2.0",
+  "productKey": "p11wN7",
+  "version": "20251117171034056"
+ },
+ "properties": [
+  {
+   "specs": {
+    "unit": "min",
+    "min": "0",
+    "max": "65535",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "remain_time",
+   "dataType": "INT",
+   "name": "Remaining Available Time",
+   "subType": "R",
+   "id": 2,
+   "sort": 0,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "specs": {
+      "unit": "W",
+      "min": "0",
+      "max": "65535",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "Typec1_output",
+     "dataType": "INT",
+     "name": "typec1输出功率",
+     "id": 2
+    },
+    {
+     "specs": {
+      "unit": "W",
+      "min": "0",
+      "max": "65535",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "Typec2_output",
+     "dataType": "INT",
+     "name": "typec2输出功率",
+     "id": 5
+    },
+    {
+     "specs": {
+      "unit": "W",
+      "min": "0",
+      "max": "200",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "Typec3_output",
+     "dataType": "INT",
+     "name": "TypeC3功率",
+     "id": 6
+    },
+    {
+     "specs": {
+      "unit": "W",
+      "min": "0",
+      "max": "200",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "Typec4_output",
+     "dataType": "INT",
+     "name": "TypeC4功率",
+     "id": 7
+    }
+   ],
+   "code": "typec_data",
+   "dataType": "STRUCT",
+   "name": "TypeC Info",
+   "subType": "RW",
+   "id": 8,
+   "sort": 1,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "specs": [
+      {
+       "dataType": "BOOL",
+       "name": "ON",
+       "value": "true"
+      },
+      {
+       "dataType": "BOOL",
+       "name": "OFF",
+       "value": "false"
+      }
+     ],
+     "code": "dc_switch",
+     "dataType": "BOOL",
+     "name": "DC Switch",
+     "id": 1
+    },
+    {
+     "specs": {
+      "unit": "W",
+      "min": "0",
+      "max": "65535",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "car1_output",
+     "dataType": "INT",
+     "name": "CAR1 Output Power",
+     "id": 2
+    },
+    {
+     "specs": {
+      "unit": "V",
+      "min": "0",
+      "max": "500",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "car1_output_voltage",
+     "dataType": "INT",
+     "name": "CAR1 Output Voltage",
+     "id": 3
+    },
+    {
+     "specs": {
+      "unit": "A",
+      "min": "0",
+      "max": "50",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "car1_output_current",
+     "dataType": "INT",
+     "name": "CAR1O utput Current",
+     "id": 4
+    }
+   ],
+   "code": "dc_data",
+   "dataType": "STRUCT",
+   "name": "DC Info",
+   "subType": "RW",
+   "id": 9,
+   "sort": 2,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "specs": [
+      {
+       "dataType": "BOOL",
+       "name": "开",
+       "value": "true"
+      },
+      {
+       "dataType": "BOOL",
+       "name": "关",
+       "value": "false"
+      }
+     ],
+     "code": "ac_switch",
+     "dataType": "BOOL",
+     "name": "AC开关",
+     "id": 1
+    },
+    {
+     "specs": {
+      "unit": "W",
+      "min": "0",
+      "max": "65535",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "ac1_output",
+     "dataType": "INT",
+     "name": "AC1 Output Power",
+     "id": 2
+    },
+    {
+     "specs": {
+      "unit": "V",
+      "min": "0",
+      "max": "500",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "ac1_output_voltage",
+     "dataType": "INT",
+     "name": "AC1 Output Voltage",
+     "id": 3
+    }
+   ],
+   "code": "ac_data",
+   "dataType": "STRUCT",
+   "name": "AC Info",
+   "subType": "RW",
+   "id": 6,
+   "sort": 3,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "",
+    "min": "0",
+    "max": "65530",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "AC_Version",
+   "dataType": "INT",
+   "name": "Inverter Version",
+   "subType": "R",
+   "id": 31,
+   "sort": 4,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "specs": [
+      {
+       "dataType": "BOOL",
+       "name": "开",
+       "value": "true"
+      },
+      {
+       "dataType": "BOOL",
+       "name": "关",
+       "value": "false"
+      }
+     ],
+     "code": "usb_switch",
+     "dataType": "BOOL",
+     "name": "USB开关",
+     "id": 1
+    },
+    {
+     "specs": {
+      "unit": "W",
+      "min": "0",
+      "max": "65535",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "USB_QC1_output",
+     "dataType": "INT",
+     "name": "USBA1输出功率",
+     "id": 2
+    },
+    {
+     "specs": {
+      "unit": "W",
+      "min": "0",
+      "max": "65535",
+      "multiple": "",
+      "step": "1"
+     },
+     "code": "USB_QC2_output",
+     "dataType": "INT",
+     "name": "USB_QC2",
+     "id": 3
+    }
+   ],
+   "code": "usb_data",
+   "dataType": "STRUCT",
+   "name": "USB Info",
+   "subType": "RW",
+   "id": 7,
+   "sort": 5,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "dataType": "ENUM",
+     "name": "100V",
+     "value": "100"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "110V",
+     "value": "110"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "120V",
+     "value": "120"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "220V",
+     "value": "220"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "230V",
+     "value": "230"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "240V",
+     "value": "240"
+    }
+   ],
+   "code": "ACvoltage_Switchover",
+   "dataType": "ENUM",
+   "name": "Output Voltage Setting",
+   "subType": "RW",
+   "id": 28,
+   "sort": 7,
+   "type": "PROPERTY",
+   "desc": "交流电输出电压切换高低"
+  },
+  {
+   "specs": [
+    {
+     "dataType": "ENUM",
+     "name": "50Hz",
+     "value": "0"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "60Hz",
+     "value": "1"
+    }
+   ],
+   "code": "Frequency_Switchover",
+   "dataType": "ENUM",
+   "name": "Output Frequency Setting",
+   "subType": "RW",
+   "id": 27,
+   "sort": 8,
+   "type": "PROPERTY",
+   "desc": "切换频率开关"
+  },
+  {
+   "specs": {
+    "unit": "℃",
+    "min": "-100",
+    "max": "100",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "temp",
+   "dataType": "INT",
+   "name": "Device Temp",
+   "subType": "R",
+   "id": 14,
+   "sort": 10,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "W",
+    "min": "0",
+    "max": "65535",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "dc_input",
+   "dataType": "INT",
+   "name": "DC Charging Input Power",
+   "subType": "R",
+   "id": 12,
+   "sort": 11,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "W",
+    "min": "0",
+    "max": "65535",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "ac_input",
+   "dataType": "INT",
+   "name": "AC Charging Input Power",
+   "subType": "R",
+   "id": 11,
+   "sort": 12,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "W",
+    "min": "0",
+    "max": "65535",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "total_output_power",
+   "dataType": "INT",
+   "name": "Total Output Power",
+   "subType": "R",
+   "id": 5,
+   "sort": 13,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "W",
+    "min": "0",
+    "max": "65535",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "total_input_power",
+   "dataType": "INT",
+   "name": "Total Input Power",
+   "subType": "R",
+   "id": 4,
+   "sort": 14,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "min",
+    "min": "0",
+    "max": "65535",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "remain_charging_time",
+   "dataType": "INT",
+   "name": "Remaining Charging Time",
+   "subType": "R",
+   "id": 3,
+   "sort": 15,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "%",
+    "min": "0",
+    "max": "100",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "battery_percentage",
+   "dataType": "INT",
+   "name": "Battery Capacity",
+   "subType": "R",
+   "id": 1,
+   "sort": 16,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": {
+    "unit": "",
+    "min": "0",
+    "max": "65535",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "BMS_Version",
+   "dataType": "INT",
+   "name": "BMS Version",
+   "subType": "R",
+   "id": 34,
+   "sort": 17,
+   "type": "PROPERTY",
+   "desc": "上传BMS版本号"
+  },
+  {
+   "specs": {
+    "unit": "%",
+    "min": "3",
+    "max": "100",
+    "multiple": "",
+    "step": "1"
+   },
+   "code": "ac_charging_limit",
+   "dataType": "INT",
+   "name": " AC Upper Limit Charging Power",
+   "subType": "RW",
+   "id": 20,
+   "sort": 18,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "dataType": "ENUM",
+     "name": "不高频上报",
+     "value": "0"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "局域网高频上报",
+     "value": "1"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "Wi-Fi高频上报",
+     "value": "2"
+    },
+    {
+     "dataType": "ENUM",
+     "name": "局域网+Wi-Fi高频上报",
+     "value": "3"
+    }
+   ],
+   "code": "high_frequency_reporting",
+   "dataType": "ENUM",
+   "name": "高频上报",
+   "subType": "RW",
+   "id": 100,
+   "sort": 19,
+   "type": "PROPERTY",
+   "desc": "有局域网，面板下发1-局域面板判断是否有局域网，网高频上报值给到设备，设备开始高频上报并上报1-局域网高频，30s后设备关闭高频上报并上报0，如果面板依旧下发1-局域网高频上报给到设备，设备继续高频上报。若面板未返回值，则设备不再高频上报。面板判断是否有局域网，若没有，面板下发2-Wi-Fi高频上报值给到设备，设备开始高频上报并上报2，30s后设备关闭高频上报并上报0，如果面板依旧下发2-Wi-F"
+  },
+  {
+   "specs": [
+    {
+     "dataType": "BOOL",
+     "name": "On",
+     "value": "true"
+    },
+    {
+     "dataType": "BOOL",
+     "name": "Off",
+     "value": "false"
+    }
+   ],
+   "code": "ac_switch",
+   "dataType": "BOOL",
+   "name": "AC Switch",
+   "subType": "RW",
+   "id": 43,
+   "sort": 25,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "dataType": "BOOL",
+     "name": "On",
+     "value": "true"
+    },
+    {
+     "dataType": "BOOL",
+     "name": "Off",
+     "value": "false"
+    }
+   ],
+   "code": "usb_switch",
+   "dataType": "BOOL",
+   "name": "USB Switch",
+   "subType": "RW",
+   "id": 44,
+   "sort": 26,
+   "type": "PROPERTY",
+   "desc": ""
+  },
+  {
+   "specs": [
+    {
+     "dataType": "BOOL",
+     "name": "On",
+     "value": "true"
+    },
+    {
+     "dataType": "BOOL",
+     "name": "Off",
+     "value": "false"
+    }
+   ],
+   "code": "dc_switch",
+   "dataType": "BOOL",
+   "name": "DC Switch",
+   "subType": "RW",
+   "id": 46,
+   "sort": 28,
+   "type": "PROPERTY",
+   "desc": ""
+  }
+ ]
+}

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -28,6 +28,8 @@ PKG = "custom_components.oukitel_power_station"
 MODULES = [
     "__init__",
     "const",
+    "tsl",
+    "product",
     "protocol",
     "cloud",
     "discovery",

--- a/tests/test_tsl.py
+++ b/tests/test_tsl.py
@@ -1,0 +1,234 @@
+"""Offline tests for the product capability layer (tsl.py + product.py).
+
+Loads the modules directly (no Home Assistant needed — the manifest layer is
+pure Python by design), same pattern as test_protocol.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import pathlib
+import sys
+import types
+
+import pytest
+
+BASE = pathlib.Path(__file__).resolve().parents[1] / "custom_components" / "oukitel_power_station"
+_pkg = types.ModuleType("ouk")
+_pkg.__path__ = [str(BASE)]
+sys.modules["ouk"] = _pkg
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(f"ouk.{name}", BASE / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"ouk.{name}"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+tsl = _load("tsl")
+const = _load("const")
+product_mod = _load("product")
+
+KNOWN_PRODUCTS = product_mod.KNOWN_PRODUCTS
+ProductManifest = product_mod.ProductManifest
+build_manifest = product_mod.build_manifest
+manifest_from_bundled = product_mod.manifest_from_bundled
+resolve_manifest = product_mod.resolve_manifest
+parse_tsl = tsl.parse_tsl
+READ_TAG_IDS = const.READ_TAG_IDS
+
+TSL_DIR = BASE / "tsl"
+
+# Tag ids from the product thing-models (see tools/tsl_*.json).
+TAG_REMAIN_TIME = 2
+TAG_REMAIN_CHARGING_TIME = 3
+TAG_TOTAL_INPUT_POWER = 4
+TAG_AC_STRUCT = 6
+TAG_TYPEC_STRUCT = 8
+TAG_LED_STATUS = 10
+TAG_TEMP = 14
+TAG_CHARGE_LIMIT = 20
+TAG_FREQUENCY = 27
+TAG_VOLTAGE = 28
+TAG_USB_SWITCH = 44
+TAG_AC_SWITCH = 43
+
+
+@pytest.fixture
+def p1500_tsl() -> dict:
+    return json.loads((TSL_DIR / "p11uve.json").read_text(encoding="utf-8"))
+
+
+@pytest.fixture
+def p2001e_tsl() -> dict:
+    return json.loads((TSL_DIR / "p11wN7.json").read_text(encoding="utf-8"))
+
+
+# --- tsl.py -----------------------------------------------------------------
+def test_parse_tsl_p1500(p1500_tsl):
+    parsed = parse_tsl(p1500_tsl)
+    assert parsed["product_key"] == "p11uve"
+    assert parsed["tsl_version"] == "1.2.0"
+    assert parsed["profile_version"] == "20241209155030563"
+    assert len(parsed["tags"]) == 21
+    # every property contributes its code to the reverse map
+    assert parsed["code_to_tag"]["total_input_power"] == TAG_TOTAL_INPUT_POWER
+    assert parsed["code_to_tag"]["led_status"] == TAG_LED_STATUS
+    assert parsed["code_to_tag"]["high_frequency_reporting"] == 100
+
+
+def test_parse_scalars_and_enums(p1500_tsl):
+    parsed = parse_tsl(p1500_tsl)
+    charge = parsed["tags"][TAG_CHARGE_LIMIT]
+    assert charge["data_type"] == "INT"
+    assert charge["sub_type"] == "RW"
+    assert charge["min"] == 0
+    assert charge["max"] == 100
+    freq = parsed["tags"][TAG_FREQUENCY]
+    assert freq["enum"] == {0: "50Hz", 1: "60Hz"}
+    voltage = parsed["tags"][TAG_VOLTAGE]
+    assert voltage["enum"][230] == "230V"
+    assert voltage["sub_type"] == "RW"
+
+
+def test_parse_structs(p1500_tsl, p2001e_tsl):
+    p1500 = parse_tsl(p1500_tsl)["tags"]
+    p2001e = parse_tsl(p2001e_tsl)["tags"]
+    # P1500: 2 Type-C ports; P2001E Plus: 4 (verified TSL diff).
+    assert sorted(p1500[TAG_TYPEC_STRUCT]["struct"]) == [2, 5]
+    assert sorted(p2001e[TAG_TYPEC_STRUCT]["struct"]) == [2, 5, 6, 7]
+    # P2001E Plus structs mirror the output switches as subtag 1; P1500 not.
+    assert 1 in p2001e[TAG_AC_STRUCT]["struct"]
+    assert 1 not in p1500[TAG_AC_STRUCT]["struct"]
+    assert p1500[TAG_AC_STRUCT]["struct"][2]["unit"] == "W"
+
+
+def test_parse_tolerates_garbage():
+    parsed = parse_tsl(
+        {
+            "profile": {"productKey": "pkX"},
+            "properties": [
+                None,
+                {"no_id": True},
+                {"id": "nope", "code": "x"},
+                {"id": 1, "dataType": "INT"},  # missing code -> skipped
+                {"id": 2, "code": "ok", "dataType": "INT", "specs": {}},
+                {"id": 3, "code": "weird_enum", "dataType": "ENUM", "specs": "junk"},
+                {
+                    "id": 4,
+                    "code": "non_finite",
+                    "dataType": "INT",
+                    "specs": {"min": "nan", "max": "inf", "step": "-inf"},
+                },
+            ],
+        }
+    )
+    assert parsed["product_key"] == "pkX"
+    assert set(parsed["tags"]) == {2, 3, 4}
+    assert parsed["code_to_tag"] == {"ok": 2, "weird_enum": 3, "non_finite": 4}
+    assert parsed["tags"][4]["min"] is None
+    assert parsed["tags"][4]["max"] is None
+    assert parsed["tags"][4]["step"] is None
+
+
+# --- product.py --------------------------------------------------------------
+def test_build_manifest_known_products(p1500_tsl, p2001e_tsl):
+    m1500 = resolve_manifest("p11uve", cloud_tsl=p1500_tsl)
+    assert m1500 is not None
+    assert m1500.product_key == "p11uve"
+    assert m1500.model == "P1500"
+    assert m1500.excluded_tags == (TAG_REMAIN_TIME, TAG_REMAIN_CHARGING_TIME)
+
+    m2001e = resolve_manifest("p11wN7", cloud_tsl=p2001e_tsl)
+    assert m2001e is not None
+    assert m2001e.product_key == "p11wN7"
+    assert m2001e.model == "P2001E Plus"
+    assert m2001e.excluded_tags == ()
+
+
+def test_known_products_cover_bundled_snapshots():
+    for pk in ("p11uve", "p11wN7"):
+        assert pk in KNOWN_PRODUCTS
+        manifest = manifest_from_bundled(pk)
+        assert manifest is not None
+        assert manifest.product_key == pk
+
+
+def test_manifest_gating(p1500_tsl, p2001e_tsl):
+    m1500 = resolve_manifest("p11uve", cloud_tsl=p1500_tsl)
+    m2001e = resolve_manifest("p11wN7", cloud_tsl=p2001e_tsl)
+    assert m1500 is not None
+    assert m2001e is not None
+    # P1500 has LED, no USB switch; P2001E Plus has USB switch, no LED.
+    assert m1500.has_tag(TAG_LED_STATUS) and not m1500.has_tag(TAG_USB_SWITCH)
+    assert m2001e.has_tag(TAG_USB_SWITCH) and not m2001e.has_tag(TAG_LED_STATUS)
+    # curated exclude: the pinned time sensors vanish on the P1500 only.
+    assert not m1500.has_tag(TAG_REMAIN_TIME)
+    assert not m1500.has_tag(TAG_REMAIN_CHARGING_TIME)
+    assert m2001e.has_tag(TAG_REMAIN_TIME)
+    # struct subtag gating
+    assert m1500.has_subtag(TAG_TYPEC_STRUCT, 2)
+    assert not m1500.has_subtag(TAG_TYPEC_STRUCT, 6)
+    assert m2001e.has_subtag(TAG_TYPEC_STRUCT, 6)
+    assert not m1500.has_subtag(999, 2)
+
+
+def test_read_tag_ids(p1500_tsl, p2001e_tsl):
+    ids1500 = build_manifest(p1500_tsl).read_tag_ids()
+    ids2001e = build_manifest(p2001e_tsl).read_tag_ids()
+    # vendor app's verified cmd17 list + product-specific tags
+    for tag in (1, 4, 5, 6, 7, 8, 9, 11, 12, 14, 20, 27, 28, 31, 34, 43, 46, 100):
+        assert tag in ids1500
+    assert TAG_LED_STATUS in ids1500 and TAG_USB_SWITCH not in ids1500
+    assert TAG_USB_SWITCH in ids2001e and TAG_LED_STATUS not in ids2001e
+    assert ids2001e == tuple(tag for tag in READ_TAG_IDS if tag in ids2001e)
+
+
+def test_cloud_only_tags(p1500_tsl):
+    cloud_only = build_manifest(p1500_tsl).cloud_only_tags()
+    assert cloud_only == (TAG_TEMP, TAG_VOLTAGE)
+
+
+def test_snapshot_roundtrip(p1500_tsl):
+    manifest = build_manifest(p1500_tsl)
+    stored = json.loads(json.dumps(manifest.to_dict()))
+    restored = ProductManifest.from_dict(stored)
+    assert restored == manifest
+    assert restored.code_to_tag == manifest.code_to_tag
+    assert restored.enum_options(TAG_FREQUENCY) == {0: "50Hz", 1: "60Hz"}
+    assert restored.has_subtag(TAG_TYPEC_STRUCT, 2)
+
+
+def test_snapshot_is_json_safe(p1500_tsl):
+    snapshot = build_manifest(p1500_tsl).to_dict()
+    json.dumps(snapshot)  # must not raise (config-entry storage)
+
+
+def test_resolve_manifest_priority(p1500_tsl):
+    bundled = manifest_from_bundled("p11uve")
+    assert bundled is not None
+    # snapshot wins over bundled, but stale local overrides are ignored
+    fake = bundled.to_dict() | {
+        "tsl_version": "snapshotted",
+        "model": "stale model",
+        "excluded_tags": [],
+    }
+    resolved = resolve_manifest("p11uve", snapshot=fake)
+    assert resolved is not None
+    assert resolved.tsl_version == "snapshotted"
+    assert resolved.model == "P1500"
+    assert resolved.excluded_tags == (TAG_REMAIN_TIME, TAG_REMAIN_CHARGING_TIME)
+    # bundled as fallback
+    resolved = resolve_manifest("p11uve")
+    assert resolved is not None
+    assert resolved.model == "P1500"
+    assert resolved.tags == bundled.tags
+    # cloud data as the last resort for an unknown product key
+    resolved = resolve_manifest("pkNew", cloud_tsl=p1500_tsl)
+    assert resolved is not None
+    assert resolved.product_key == "p11uve"  # taken from the TSL payload
+    # nothing available -> None
+    assert resolve_manifest("pkUnknown") is None


### PR DESCRIPTION
## What
The foundation for multi-model support (P1500 next PR; any WonderFree-family station later): **model knowledge moves out of code into per-product manifests derived from the product thing-model (TSL)**.

- `tsl.py` — pure parser: productTSL payload → compact manifest (tag specs, units, ranges, enum maps, struct subtags).
- `manifest.py` — `ProductManifest` + curated overrides + resolver with priority: **entry snapshot → bundled TSL → live cloud fetch** (a new family member works on day one, before we ship its snapshot).
- `tsl/p11wN7.json` (P2001E Plus — the existing snapshot from `tools/`, normalized) and `tsl/p11uve.json` (**P1500 — new**, fetched from the cloud against my account).
- `tests/test_tsl.py` — 12 offline checks (parse scalars/enums/structs, garbage-tolerance, gating, read-list derivation, snapshot round-trip, resolver priority).

**Not wired into the runtime yet** — the coordinator/platforms adopt the manifest in the follow-up P1500-support PR, so this PR changes no behavior and stays small to review. Pure Python, no HA imports (same pattern as `protocol.py`), so it also runs in plain pytest without HA.

## Why this design
Platforms will never ask "is this a P1500?" — they ask the manifest "does this tag (or struct subtag) exist, and is it excluded on this product?". That kills model `if`s and makes the verified TSL diff the single source of truth (21 shared tags; P1500-only LED tag 10; P2001E+-only usb_switch 44; Type-C struct 2 vs 4 ports; struct switch mirrors only on p11wN7; P1500's time tags 2/3 pinned to 5940 → curated exclude).

## How tested
- 14/14 offline tests pass (`test_tsl.py` + existing protocol/cloud); ruff clean.
- The identical layer has run on my production HA with the P1500 since 2026-09-07 (manifest snapshot created at setup, entities gated by it) — the follow-up PR references that live validation.