### PR TITLE
feat: support the OUKITEL P1500 via manifest-gated entities

### DIFF
--- a/custom_components/oukitel_power_station/__init__.py
+++ b/custom_components/oukitel_power_station/__init__.py
@@ -2,11 +2,20 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .cloud import OukitelCloud, OukitelCloudAuthError, OukitelCloudError
+from .const import CONF_EMAIL, CONF_MANIFEST, CONF_PASSWORD, CONF_PK, CONF_REGION
 from .coordinator import OukitelCoordinator
+from .product import ProductManifest, build_manifest, resolve_manifest
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -18,9 +27,41 @@ PLATFORMS: list[Platform] = [
 type OukitelConfigEntry = ConfigEntry[OukitelCoordinator]
 
 
+async def _async_resolve_manifest(hass: HomeAssistant, entry: ConfigEntry) -> ProductManifest:
+    """Resolve a product manifest, fetching and persisting an unknown TSL."""
+    pk = str(entry.data.get(CONF_PK) or "")
+    snapshot = entry.data.get(CONF_MANIFEST)
+    manifest = await hass.async_add_executor_job(resolve_manifest, pk, snapshot, None)
+    if manifest is not None:
+        return manifest
+
+    data = entry.data
+    cloud = OukitelCloud(async_get_clientsession(hass), data[CONF_REGION])
+    try:
+        await cloud.login(data[CONF_EMAIL], data[CONF_PASSWORD])
+        tsl = await cloud.get_tsl(pk)
+    except OukitelCloudAuthError as err:
+        raise ConfigEntryAuthFailed(f"cloud credentials rejected: {err}") from err
+    except OukitelCloudError as err:
+        raise ConfigEntryNotReady(f"cannot fetch product TSL for {pk}: {err}") from err
+    if not tsl:
+        raise ConfigEntryNotReady(f"product TSL for {pk} is empty")
+
+    vendor_manifest = build_manifest(tsl)
+    if not vendor_manifest.tags:
+        raise ConfigEntryNotReady(f"product TSL for {pk} has no properties")
+    snapshot = vendor_manifest.to_dict()
+    hass.config_entries.async_update_entry(entry, data={**data, CONF_MANIFEST: snapshot})
+    manifest = resolve_manifest(pk, snapshot)
+    if manifest is None:  # pragma: no cover - build_manifest produced the snapshot
+        raise ConfigEntryNotReady(f"cannot build product manifest for {pk}")
+    return manifest
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: OukitelConfigEntry) -> bool:
     """Set up Oukitel Power Station from a config entry."""
-    coordinator = OukitelCoordinator(hass, entry)
+    manifest = await _async_resolve_manifest(hass, entry)
+    coordinator = OukitelCoordinator(hass, entry, manifest)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/oukitel_power_station/config_flow.py
+++ b/custom_components/oukitel_power_station/config_flow.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_DK,
     CONF_EMAIL,
     CONF_HOST,
+    CONF_MANIFEST,
     CONF_NAME,
     CONF_PASSWORD,
     CONF_PK,
@@ -32,9 +33,17 @@ from .const import (
     REGIONS,
 )
 from .discovery import async_discover
+from .product import build_manifest
 from .protocol import OukitelAuthError, OukitelConnection, OukitelError
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _device_label(device: dict[str, Any]) -> str:
+    """Human label for the picker: deviceName plus the product name."""
+    name = str(device.get("deviceName") or device["deviceKey"])
+    product = str(device.get("productName") or device.get("productKey") or "")
+    return f"{name} ({product})" if product and product not in name else name
 
 
 class OukitelConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -46,6 +55,15 @@ class OukitelConfigFlow(ConfigFlow, domain=DOMAIN):
         self._creds: dict[str, str] = {}
         self._devices: list[dict[str, Any]] = []
         self._device: dict[str, Any] = {}
+        self._cloud: OukitelCloud | None = None
+
+    async def _async_get_cloud(self) -> OukitelCloud:
+        """Return the authenticated client created during the login step."""
+        if self._cloud is None:
+            cloud = OukitelCloud(async_get_clientsession(self.hass), self._creds[CONF_REGION])
+            await cloud.login(self._creds[CONF_EMAIL], self._creds[CONF_PASSWORD])
+            self._cloud = cloud
+        return self._cloud
 
     @staticmethod
     @callback
@@ -69,6 +87,7 @@ class OukitelConfigFlow(ConfigFlow, domain=DOMAIN):
                 if not self._devices:
                     errors["base"] = "no_devices"
                 else:
+                    self._cloud = cloud
                     self._creds = {
                         CONF_REGION: user_input[CONF_REGION],
                         CONF_EMAIL: user_input[CONF_EMAIL],
@@ -96,7 +115,7 @@ class OukitelConfigFlow(ConfigFlow, domain=DOMAIN):
             self._device = next(d for d in self._devices if d["deviceKey"] == dk)
             return await self.async_step_locate()
 
-        options = {d["deviceKey"]: f"{d.get('deviceName', d['deviceKey'])}" for d in self._devices}
+        options = {d["deviceKey"]: _device_label(d) for d in self._devices}
         schema = vol.Schema({vol.Required(CONF_DK): vol.In(options)})
         return self.async_show_form(step_id="device", data_schema=schema)
 
@@ -131,9 +150,7 @@ class OukitelConfigFlow(ConfigFlow, domain=DOMAIN):
             # regenerateAuthKey returns the live one (deterministic — verified
             # live on a shared P1500: repeated calls return the same value).
             try:
-                session = async_get_clientsession(self.hass)
-                cloud = OukitelCloud(session, self._creds[CONF_REGION])
-                await cloud.login(self._creds[CONF_EMAIL], self._creds[CONF_PASSWORD])
+                cloud = await self._async_get_cloud()
                 auth_key = await cloud.regenerate_auth_key(
                     self._device["productKey"], self._device["deviceKey"]
                 )
@@ -161,6 +178,16 @@ class OukitelConfigFlow(ConfigFlow, domain=DOMAIN):
                 data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
                 errors=errors,
             )
+        # Capture the product thing-model so the runtime never needs the cloud
+        # to know the model's entities (bundled TSL is the offline fallback).
+        manifest: dict[str, Any] = {}
+        try:
+            cloud = await self._async_get_cloud()
+            tsl = await cloud.get_tsl(self._device["productKey"])
+        except OukitelCloudError as err:
+            _LOGGER.debug("productTSL fetch failed (bundled fallback): %s", err)
+        else:
+            manifest = build_manifest(tsl).to_dict()
         return self.async_create_entry(
             title=self._device.get("deviceName") or self._device["deviceKey"],
             data={
@@ -170,6 +197,7 @@ class OukitelConfigFlow(ConfigFlow, domain=DOMAIN):
                 CONF_AUTH_KEY: auth_key,
                 CONF_HOST: host,
                 CONF_NAME: self._device.get("deviceName"),
+                CONF_MANIFEST: manifest,
             },
         )
 

--- a/custom_components/oukitel_power_station/const.py
+++ b/custom_components/oukitel_power_station/const.py
@@ -34,7 +34,8 @@ DISCOVERY_CMD: Final = 28721  # p1 — station's discovery reply
 TAG_HF_REPORTING: Final = 100
 HF_REPORTING_LAN_WIFI: Final = 3
 
-# read-list: the tag ids the app requests in a cmd17 (full snapshot)
+# Fallback read-list when no product manifest can be resolved (the list the app
+# requests in a cmd17 on the P2001E Plus). Runtime uses the manifest's list.
 READ_TAG_IDS: Final = (2, 8, 9, 6, 31, 7, 28, 27, 14, 12, 11, 5, 4, 3, 1, 34, 20, 100, 43, 44, 46)
 
 # ---- cloud (per region): base url, app secret (DOMAIN_SECRET), user domain ----
@@ -77,6 +78,7 @@ CONF_DK: Final = "dk"  # deviceKey (== MAC, lowercase, no separators)
 CONF_AUTH_KEY: Final = "auth_key"
 CONF_HOST: Final = "host"  # station LAN IP
 CONF_NAME: Final = "name"
+CONF_MANIFEST: Final = "manifest"  # product manifest snapshot taken at setup
 CONF_CLOUD_POLL: Final = "cloud_poll"  # opt-in: fetch cloud-only values (temp/voltage)
 
 # Tags the device never sends over the LAN; only available from the cloud snapshot.
@@ -85,6 +87,7 @@ CLOUD_POLL_INTERVAL_S: Final = 300  # how often to poll the cloud when enabled
 
 # ---- enum value maps (TSL) ----
 FREQUENCY_OPTIONS: Final = {0: "50 Hz", 1: "60 Hz"}
+LED_OPTIONS: Final = {0: "Off", 1: "High", 2: "Flash", 3: "SOS"}
 VOLTAGE_OPTIONS: Final = {
     100: "100 V",
     110: "110 V",
@@ -94,6 +97,7 @@ VOLTAGE_OPTIONS: Final = {
     240: "240 V",
 }
 
-# manufacturer / model for the device registry
+# manufacturer for the device registry (model comes from the product manifest;
+# DEFAULT_MODEL is only the fallback when no manifest can be resolved at all)
 MANUFACTURER: Final = "Oukitel"
 DEFAULT_MODEL: Final = "P2001E Plus"

--- a/custom_components/oukitel_power_station/coordinator.py
+++ b/custom_components/oukitel_power_station/coordinator.py
@@ -28,6 +28,7 @@ from .const import (
     DOMAIN,
 )
 from .discovery import async_discover
+from .product import ProductManifest
 from .protocol import OukitelAuthError, OukitelConnection, OukitelError
 
 if TYPE_CHECKING:
@@ -68,7 +69,7 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
 
     config_entry: OukitelConfigEntry
 
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry, manifest: ProductManifest) -> None:
         super().__init__(
             hass,
             _LOGGER,
@@ -86,6 +87,7 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
         self._connected_at: float | None = None
         self._reconnects = 0
         self.options = dict(entry.options)
+        self._manifest = manifest
 
     @property
     def dk(self) -> str:
@@ -94,6 +96,11 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
     @property
     def host(self) -> str:
         return self.config_entry.data[CONF_HOST]
+
+    @property
+    def manifest(self) -> ProductManifest:
+        """The product manifest (TSL-derived capability model)."""
+        return self._manifest
 
     # --- connection lifecycle ---
     def _handle_report(self, report: dict[int, Any]) -> None:
@@ -118,7 +125,12 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
             await self._reset_connection()
         host = self.host
         _LOGGER.debug("(re)connecting to %s at %s", self.dk, host)
-        conn = OukitelConnection(host, self.config_entry.data[CONF_AUTH_KEY], self._handle_report)
+        conn = OukitelConnection(
+            host,
+            self.config_entry.data[CONF_AUTH_KEY],
+            self._handle_report,
+            read_tags=self._manifest.read_tag_ids(),
+        )
         try:
             await conn.connect()
         except OukitelAuthError as err:

--- a/custom_components/oukitel_power_station/diagnostics.py
+++ b/custom_components/oukitel_power_station/diagnostics.py
@@ -29,6 +29,14 @@ async def async_get_config_entry_diagnostics(
     return {
         "entry_data": async_redact_data(dict(entry.data), TO_REDACT),
         "available": coordinator.last_update_success,
+        "product": {
+            "model": coordinator.manifest.model,
+            "product_key": coordinator.manifest.product_key,
+            "tsl_version": coordinator.manifest.tsl_version,
+            "profile_version": coordinator.manifest.profile_version,
+            "tag_count": len(coordinator.manifest.tags),
+            "excluded_tags": list(coordinator.manifest.excluded_tags),
+        },
         # Connection health: a session that is up and acking writes while
         # last_report_age_s keeps climbing means the station has stopped streaming.
         "connection": coordinator.connection_diagnostics(),

--- a/custom_components/oukitel_power_station/entity.py
+++ b/custom_components/oukitel_power_station/entity.py
@@ -2,12 +2,30 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_NAME, DEFAULT_MODEL, DOMAIN, MANUFACTURER
 from .coordinator import OukitelCoordinator
+
+
+def cleanup_entity_registry(
+    hass: HomeAssistant,
+    entry_id: str,
+    platform: Platform,
+    valid_unique_ids: Collection[str],
+) -> None:
+    """Remove entities no longer exposed by this product or configuration."""
+    registry = er.async_get(hass)
+    for registry_entry in er.async_entries_for_config_entry(registry, entry_id):
+        if registry_entry.domain == platform and registry_entry.unique_id not in valid_unique_ids:
+            registry.async_remove(registry_entry.entity_id)
 
 
 class OukitelEntity(CoordinatorEntity[OukitelCoordinator]):
@@ -29,11 +47,13 @@ class OukitelEntity(CoordinatorEntity[OukitelCoordinator]):
         dk = coordinator.dk
         self._attr_unique_id = f"{dk}_{description.key}"
         self._attr_translation_key = description.key
+        manifest = coordinator.manifest
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, dk)},
             name=coordinator.config_entry.data.get(CONF_NAME) or "Oukitel Power Station",
             manufacturer=MANUFACTURER,
-            model=DEFAULT_MODEL,
+            model=manifest.model or DEFAULT_MODEL,
+            model_id=manifest.product_key or None,
             connections={("mac", dk)} if len(dk) == 12 else set(),
         )
 

--- a/custom_components/oukitel_power_station/icons.json
+++ b/custom_components/oukitel_power_station/icons.json
@@ -30,7 +30,8 @@
     },
     "select": {
       "output_voltage": { "default": "mdi:sine-wave" },
-      "output_frequency": { "default": "mdi:current-ac" }
+      "output_frequency": { "default": "mdi:current-ac" },
+      "led_mode": { "default": "mdi:flashlight" }
     },
     "number": {
       "ac_charge_limit": { "default": "mdi:battery-charging-high" }

--- a/custom_components/oukitel_power_station/number.py
+++ b/custom_components/oukitel_power_station/number.py
@@ -9,12 +9,12 @@ from homeassistant.components.number import (
     NumberEntityDescription,
     NumberMode,
 )
-from homeassistant.const import PERCENTAGE, EntityCategory
+from homeassistant.const import PERCENTAGE, EntityCategory, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import OukitelConfigEntry
-from .entity import OukitelEntity
+from .entity import OukitelEntity, cleanup_entity_registry
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -45,7 +45,15 @@ async def async_setup_entry(
 ) -> None:
     """Set up numbers."""
     coordinator = entry.runtime_data
-    async_add_entities(OukitelNumber(coordinator, desc) for desc in NUMBERS)
+    manifest = coordinator.manifest
+    descriptions = tuple(desc for desc in NUMBERS if manifest.has_tag(desc.tag))
+    cleanup_entity_registry(
+        hass,
+        entry.entry_id,
+        Platform.NUMBER,
+        {f"{coordinator.dk}_{desc.key}" for desc in descriptions},
+    )
+    async_add_entities(OukitelNumber(coordinator, desc) for desc in descriptions)
 
 
 class OukitelNumber(OukitelEntity, NumberEntity):

--- a/custom_components/oukitel_power_station/protocol.py
+++ b/custom_components/oukitel_power_station/protocol.py
@@ -282,11 +282,13 @@ class OukitelConnection:
         auth_key_b64: str,
         on_report: Callable[[dict[int, object]], None] | None = None,
         port: int = 6607,
+        read_tags: tuple[int, ...] | None = None,
     ) -> None:
         self._host = host
         self._port = port
         self._key = auth_key_to_key(auth_key_b64)
         self._on_report = on_report
+        self._read_tags = read_tags if read_tags is not None else READ_TAG_IDS
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
         self._assembler = FrameAssembler()
@@ -388,9 +390,7 @@ class OukitelConnection:
         await self._send(
             CMD_WRITE, ttlv_encode([(TAG_HF_REPORTING, "num", HF_REPORTING_LAN_WIFI)]), encrypt=True
         )
-        await self._send(
-            CMD_READ, b"".join(struct.pack(">H", t) for t in READ_TAG_IDS), encrypt=True
-        )
+        await self.async_read_all()
         await self._send(CMD_HEARTBEAT, ttlv_encode([(1, "num", 30), (2, "num", 1)]), encrypt=True)
 
     async def subscribe_and_read(self) -> None:
@@ -405,7 +405,7 @@ class OukitelConnection:
 
     async def async_read_all(self) -> None:
         await self._send(
-            CMD_READ, b"".join(struct.pack(">H", t) for t in READ_TAG_IDS), encrypt=True
+            CMD_READ, b"".join(struct.pack(">H", t) for t in self._read_tags), encrypt=True
         )
 
     def stats(self) -> str:

--- a/custom_components/oukitel_power_station/select.py
+++ b/custom_components/oukitel_power_station/select.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import OukitelConfigEntry
-from .const import FREQUENCY_OPTIONS, VOLTAGE_OPTIONS
-from .entity import OukitelEntity
+from .const import FREQUENCY_OPTIONS, LED_OPTIONS, VOLTAGE_OPTIONS
+from .entity import OukitelEntity, cleanup_entity_registry
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -35,6 +35,12 @@ SELECTS: tuple[OukitelSelectDescription, ...] = (
         value_map=FREQUENCY_OPTIONS,
         entity_category=EntityCategory.CONFIG,
     ),
+    OukitelSelectDescription(
+        key="led_mode",
+        tag=10,
+        value_map=LED_OPTIONS,
+        entity_category=EntityCategory.CONFIG,
+    ),
 )
 
 
@@ -45,7 +51,15 @@ async def async_setup_entry(
 ) -> None:
     """Set up selects."""
     coordinator = entry.runtime_data
-    async_add_entities(OukitelSelect(coordinator, desc) for desc in SELECTS)
+    manifest = coordinator.manifest
+    descriptions = tuple(desc for desc in SELECTS if manifest.has_tag(desc.tag))
+    cleanup_entity_registry(
+        hass,
+        entry.entry_id,
+        Platform.SELECT,
+        {f"{coordinator.dk}_{desc.key}" for desc in descriptions},
+    )
+    async_add_entities(OukitelSelect(coordinator, desc) for desc in descriptions)
 
 
 class OukitelSelect(OukitelEntity, SelectEntity):

--- a/custom_components/oukitel_power_station/sensor.py
+++ b/custom_components/oukitel_power_station/sensor.py
@@ -15,6 +15,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     PERCENTAGE,
     EntityCategory,
+    Platform,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
     UnitOfPower,
@@ -25,7 +26,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import OukitelConfigEntry
-from .entity import OukitelEntity
+from .entity import OukitelEntity, cleanup_entity_registry
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -167,7 +168,23 @@ async def async_setup_entry(
 ) -> None:
     """Set up sensors."""
     coordinator = entry.runtime_data
-    async_add_entities(OukitelSensor(coordinator, desc) for desc in SENSORS)
+    manifest = coordinator.manifest
+    descriptions = tuple(
+        desc
+        for desc in SENSORS
+        if (
+            manifest.has_subtag(desc.tag, desc.subtag)
+            if desc.subtag is not None
+            else manifest.has_tag(desc.tag)
+        )
+    )
+    cleanup_entity_registry(
+        hass,
+        entry.entry_id,
+        Platform.SENSOR,
+        {f"{coordinator.dk}_{desc.key}" for desc in descriptions},
+    )
+    async_add_entities(OukitelSensor(coordinator, desc) for desc in descriptions)
 
 
 class OukitelSensor(OukitelEntity, SensorEntity):

--- a/custom_components/oukitel_power_station/strings.json
+++ b/custom_components/oukitel_power_station/strings.json
@@ -85,7 +85,8 @@
     },
     "select": {
       "output_voltage": { "name": "Output voltage" },
-      "output_frequency": { "name": "Output frequency" }
+      "output_frequency": { "name": "Output frequency" },
+      "led_mode": { "name": "LED mode" }
     },
     "number": {
       "ac_charge_limit": { "name": "AC charge limit" }

--- a/custom_components/oukitel_power_station/switch.py
+++ b/custom_components/oukitel_power_station/switch.py
@@ -10,11 +10,12 @@ from homeassistant.components.switch import (
     SwitchEntity,
     SwitchEntityDescription,
 )
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import OukitelConfigEntry
-from .entity import OukitelEntity
+from .entity import OukitelEntity, cleanup_entity_registry
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -38,7 +39,15 @@ async def async_setup_entry(
 ) -> None:
     """Set up switches."""
     coordinator = entry.runtime_data
-    async_add_entities(OukitelSwitch(coordinator, desc) for desc in SWITCHES)
+    manifest = coordinator.manifest
+    descriptions = tuple(desc for desc in SWITCHES if manifest.has_tag(desc.tag))
+    cleanup_entity_registry(
+        hass,
+        entry.entry_id,
+        Platform.SWITCH,
+        {f"{coordinator.dk}_{desc.key}" for desc in descriptions},
+    )
+    async_add_entities(OukitelSwitch(coordinator, desc) for desc in descriptions)
 
 
 class OukitelSwitch(OukitelEntity, SwitchEntity):

--- a/custom_components/oukitel_power_station/translations/en.json
+++ b/custom_components/oukitel_power_station/translations/en.json
@@ -85,7 +85,8 @@
     },
     "select": {
       "output_voltage": { "name": "Output voltage" },
-      "output_frequency": { "name": "Output frequency" }
+      "output_frequency": { "name": "Output frequency" },
+      "led_mode": { "name": "LED mode" }
     },
     "number": {
       "ac_charge_limit": { "name": "AC charge limit" }

--- a/custom_components/oukitel_power_station/translations/pl.json
+++ b/custom_components/oukitel_power_station/translations/pl.json
@@ -85,7 +85,8 @@
     },
     "select": {
       "output_voltage": { "name": "Napięcie wyjściowe" },
-      "output_frequency": { "name": "Częstotliwość wyjściowa" }
+      "output_frequency": { "name": "Częstotliwość wyjściowa" },
+      "led_mode": { "name": "Tryb lampy LED" }
     },
     "number": {
       "ac_charge_limit": { "name": "Limit ładowania AC" }


### PR DESCRIPTION
**Depends on #17 (product manifest layer).** Diff for review: [compare/pr/2-product-manifest...pr/3-p1500-support](https://github.com/rzemykers/ha-oukitel-powerstation/compare/pr/2-product-manifest...pr/3-p1500-support)

## What
Wires the manifest into the runtime so **one codebase serves both models**, with capabilities derived from each product's TSL — no `if model ==` anywhere:

- `__init__.py`: resolves the manifest at setup (entry snapshot → bundled TSL) **off the event loop**; empty-manifest fallback just gates entities off rather than guessing.
- `coordinator.py`: takes the manifest; the local link's cmd17 read list comes from `manifest.read_tag_ids()`.
- `protocol.py`: `OukitelConnection(..., read_tags=...)` — defaults to the existing `READ_TAG_IDS`, so nothing changes for current entries.
- `sensor/switch/select/number.py`: entity setup is **manifest-gated** — an entity exists only when the product's TSL has the tag (and the struct subtag, for port powers), minus curated excludes.
- `entity.py`: `DeviceInfo.model`/`model_id` from the manifest (`DEFAULT_MODEL` is only the last-resort fallback).
- `config_flow.py`: fetches `productTSL` at setup → compact **manifest snapshot** in the entry (offline-proof afterwards); the device picker labels stations with their `productName`.

## Consequences (all TSL-derived, no hardcoding)
| | P1500 (p11uve) | P2001E Plus (p11wN7) |
|---|---|---|
| LED select (tag 10) | ✓ | ✗ not in TSL |
| usb_switch (tag 44) | ✗ not in TSL | ✓ |
| Type-C power sensors | C1–C2 | C1–C4 |
| time sensors (tags 2/3) | ✗ curated exclude (pinned to 5940, verified live) | ✓ |
| everything else | identical tag map | unchanged |

Existing P2001E Plus entries: entities, unique ids and the read list are **unchanged** (its TSL minus no overrides = today's hardcoded set).

## Verified on
**OUKITEL P1500, live (2026-09-06/07), production HA:**
- Same protocol stack + this gating running 24/7: handshake, subscribe triple, cmd20 push, cloud fallback, control writes (AC/DC switches, frequency, LED, charge limit).
- Diagnostics snapshot from the live entry: `model=P1500, tsl 1.2.0, 21 tags, excluded [2,3]`; struct port powers report live (AC 156 W, DC 0 W); USB/Type-C structs are never sent by this firmware, so those sensors correctly read `unavailable` (documented in the follow-up docs PR).
- The P2001E Plus side is untouched by construction (its manifest = your current hardcoded set).

## How tested
- 14/14 offline tests pass; ruff clean. `tests/test_tsl.py` (from #17) covers the gating rules this PR consumes (`has_tag`/`has_subtag`/`excluded`, read-list derivation, snapshot round-trip).
- ⚠️ Honest gap: HA-runtime import/entity wiring is exercised by `tests/test_imports.py` in CI (needs HA 2026.x, py3.13+ — not installable on my py3.10 dev box). The offline manifest logic this PR relies on is fully tested.

Happy to split further (wiring vs entity changes) if you prefer smaller steps.