### PR TITLE
fix: detect and recover when the station stops streaming telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ once from the Quectel cloud using your account, then connects directly to the st
 
 > Tip: give the station a DHCP reservation. If its IP changes, the integration re-discovers it by MAC.
 
+> ⚠️ **Do not block the station's internet access.** Control and polling stay local, but the station
+> only streams its telemetry once it has a live cloud connection. Firewalled off the internet it still
+> completes the handshake and acks commands, yet sends no data at all — so every sensor goes
+> unavailable while the device looks perfectly reachable. This is device behaviour, not something the
+> integration can work around. See issue #6.
+
 ## Entities
 **Sensors:** Battery %, Remaining time, Charging time, Total input power, Total output power,
 AC charging input power, DC charging input power, Temperature, Inverter version, BMS version.

--- a/REVERSE_ENGINEERING.md
+++ b/REVERSE_ENGINEERING.md
@@ -423,13 +423,24 @@ Fetched via `GET https://iot-api.quecteleu.com/v2/binding/enduserapi/productTSL?
 | **8** | typec_data | TypeC Info | STRUCT | sub: typec1..typec4 output power(W) |
 | **9** | dc_data | DC Info | STRUCT | sub: DC switch, CAR1 power(W)/voltage(V)/current(A) |
 
-Telemetry can stall while the session stays healthy (issue #6, observed 2026-09-07): after a
-Home Assistant restart the station completed the `p2..p5` handshake (login result **0**), acked every
-`cmd19` write with `p6`, and sent **zero** `cmd20` reports and no reply to `cmd17` — for over 6
-minutes, to two independent clients at once. Re-writing `tag100` (including 0 then 3, to force a
-change rather than an idempotent write) did not restart the stream. So the stall is device-wide, not
-bound to one session. The station was firewalled off the internet at the time, which is the leading
-explanation: local telemetry appears to require cloud reachability.
+### ⚠️ The station needs internet access to stream LAN telemetry (CONFIRMED 2026-09-07, issue #6)
+
+The local link is *not* fully independent of the cloud. With the station firewalled off the internet
+(UniFi policy, destination `Internet`, both Block and Reject):
+
+- `p2..p5` handshake completes normally — login result **0**, encryption on.
+- every `cmd19` write is acked with `p6` (23 of 23 over 7 minutes).
+- **zero** `cmd20` reports arrive, and `cmd17` reads are never answered.
+- the stall is **device-wide**, not per-session: two independent clients saw it simultaneously.
+- re-writing `tag100` — including 0 then 3, to force a change rather than an idempotent write — does
+  not restart the stream.
+
+Removing the firewall rule restored telemetry **within seconds**, with no reconnect needed: the
+device resumes streaming over the existing session. So the station apparently gates its LAN reporting
+on having a live cloud connection, while still serving the handshake and writes without one.
+
+Practical consequence: an integration cannot distinguish this from a healthy session by looking at
+the socket — only by noticing that no telemetry has arrived (see the coordinator's stall detection).
 
 Note on the input-power tags (issue #12): tags 11/12 are the **charging** share only, not the total
 draw from the source. Tag 4 (`total_input_power`) is everything coming in, so charging from AC with a

--- a/REVERSE_ENGINEERING.md
+++ b/REVERSE_ENGINEERING.md
@@ -423,6 +423,14 @@ Fetched via `GET https://iot-api.quecteleu.com/v2/binding/enduserapi/productTSL?
 | **8** | typec_data | TypeC Info | STRUCT | sub: typec1..typec4 output power(W) |
 | **9** | dc_data | DC Info | STRUCT | sub: DC switch, CAR1 power(W)/voltage(V)/current(A) |
 
+Telemetry can stall while the session stays healthy (issue #6, observed 2026-09-07): after a
+Home Assistant restart the station completed the `p2..p5` handshake (login result **0**), acked every
+`cmd19` write with `p6`, and sent **zero** `cmd20` reports and no reply to `cmd17` — for over 6
+minutes, to two independent clients at once. Re-writing `tag100` (including 0 then 3, to force a
+change rather than an idempotent write) did not restart the stream. So the stall is device-wide, not
+bound to one session. The station was firewalled off the internet at the time, which is the leading
+explanation: local telemetry appears to require cloud reachability.
+
 Note on the input-power tags (issue #12): tags 11/12 are the **charging** share only, not the total
 draw from the source. Tag 4 (`total_input_power`) is everything coming in, so charging from AC with a
 load on the AC output gives `tag4 = tag11 + AC output power` (reported: 570 = 500 + 70).

--- a/custom_components/oukitel_power_station/coordinator.py
+++ b/custom_components/oukitel_power_station/coordinator.py
@@ -256,9 +256,10 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
             stats = self._conn.stats() if self._conn else "no session"
             _LOGGER.warning(
                 "%s: connected and writes are being acked, but no telemetry for %.0fs "
-                "(%s). Dropping the session to resubscribe. If this repeats, the station "
-                "is most likely unable to reach the Quectel cloud -- check for a firewall "
-                "rule blocking its internet access -- or another app holds its report stream",
+                "(%s). Dropping the session to resubscribe. The usual cause is the station "
+                "having no internet access: it keeps serving the handshake and writes, but "
+                "only streams telemetry while it can reach the Quectel cloud. Check for a "
+                "firewall rule blocking it (see issue #6)",
                 self.dk,
                 age,
                 stats,

--- a/custom_components/oukitel_power_station/coordinator.py
+++ b/custom_components/oukitel_power_station/coordinator.py
@@ -36,6 +36,31 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 _UPDATE_INTERVAL = timedelta(seconds=60)
+# A healthy station streams cmd20 reports continuously. It can however sit in a state
+# where it completes the handshake and acks every write while never sending telemetry
+# (observed with the device unable to reach the Quectel cloud). Nothing else notices:
+# the acks keep the read loop fed so the protocol read watchdog stays happy, and the
+# update method only *sends* a read, so it would report success on stale data forever.
+_REPORT_TIMEOUT = 150.0
+
+
+def stall_age(
+    now: float,
+    last_report: float | None,
+    connected_at: float | None,
+    timeout: float = _REPORT_TIMEOUT,
+) -> float | None:
+    """Return how long telemetry has been missing, or None if the stream looks healthy.
+
+    Measured from the last report, or from the connect time when none has arrived yet,
+    so a fresh session gets a grace period before being declared stalled. Pure, so the
+    policy can be tested without a Home Assistant instance.
+    """
+    reference = last_report or connected_at
+    if reference is None:
+        return None
+    age = now - reference
+    return age if age > timeout else None
 
 
 class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
@@ -57,6 +82,9 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
         self._auth_refetched = False
         self._cloud: OukitelCloud | None = None
         self._last_cloud_poll: float = 0.0
+        self._last_report: float | None = None
+        self._connected_at: float | None = None
+        self._reconnects = 0
 
     @property
     def dk(self) -> str:
@@ -69,15 +97,24 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
     # --- connection lifecycle ---
     def _handle_report(self, report: dict[int, Any]) -> None:
         _LOGGER.debug("report=%s", report)
+        self._last_report = self.hass.loop.time()
         # Replace, don't merge: a read returns the full struct, so replacing lets a
         # port that turned off (dropped/zeroed sub-tag) actually clear instead of
         # keeping its last non-zero value forever.
         self._state.update(report)
         self.async_set_updated_data(dict(self._state))
 
+    def _listening(self) -> bool:
+        return self._listen_task is not None and not self._listen_task.done()
+
     async def _ensure_connected(self) -> None:
-        if self._conn is not None:
+        if self._conn is not None and self._listening():
             return
+        if self._conn is not None:
+            # A connection without a running reader decodes nothing: reads would be
+            # sent into a void and the cached state returned as if it were fresh.
+            _LOGGER.debug("connection has no live listener; dropping it")
+            await self._reset_connection()
         host = self.host
         _LOGGER.debug("(re)connecting to %s at %s", self.dk, host)
         conn = OukitelConnection(host, self.config_entry.data[CONF_AUTH_KEY], self._handle_report)
@@ -101,11 +138,20 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
                 _LOGGER.debug("connect to %s failed (%s); discovery found %s", host, err, new_ip)
             raise UpdateFailed(f"cannot connect to {host}") from err
         self._conn = conn
+        self._connected_at = self.hass.loop.time()
+        self._last_report = None
+        self._reconnects += 1
         _LOGGER.debug("connected to %s; subscribing", self.dk)
-        await conn.subscribe_and_read()
+        # Start the reader before subscribing: if the subscribe fails we must not be
+        # left holding a connection nobody reads.
         self._listen_task = self.config_entry.async_create_background_task(
             self.hass, self._listen(), name=f"{DOMAIN}_listen_{self.dk}"
         )
+        try:
+            await conn.subscribe_and_read()
+        except OukitelError:
+            await self._reset_connection()
+            raise
 
     async def _listen(self) -> None:
         assert self._conn is not None
@@ -120,9 +166,16 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
             await self.async_request_refresh()
 
     async def _reset_connection(self) -> None:
+        task = self._listen_task
+        self._listen_task = None
+        # _listen() calls this from inside the listen task itself; never cancel self.
+        if task is not None and task is not asyncio.current_task() and not task.done():
+            task.cancel()
         if self._conn is not None:
             await self._conn.close()
             self._conn = None
+        self._connected_at = None
+        self._last_report = None
 
     async def _refetch_auth_key(self) -> None:
         """Re-fetch authKey from the cloud using stored credentials (reauth on failure)."""
@@ -173,25 +226,58 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
             _LOGGER.debug("cloud poll merged %s", updates)
             self._state.update(updates)
 
+    def _telemetry_stalled(self) -> float | None:
+        """Age of the last report if the device has gone quiet, else None."""
+        return stall_age(self.hass.loop.time(), self._last_report, self._connected_at)
+
     async def _async_update_data(self) -> dict[int, Any]:
-        try:
-            await self._ensure_connected()
-            assert self._conn is not None
-            await self._conn.async_read_all()
-        except ConfigEntryAuthFailed:
-            raise
-        except UpdateFailed:
+        # Two attempts: a session the device reset between polls fails on the first
+        # send, and reconnecting takes well under a second. Retrying here keeps that
+        # invisible instead of blanking every entity until the next cycle.
+        for attempt in (1, 2):
+            try:
+                await self._ensure_connected()
+                assert self._conn is not None
+                await self._conn.async_read_all()
+                break
+            except ConfigEntryAuthFailed:
+                raise
+            except UpdateFailed:
+                await self._reset_connection()
+                raise
+            except OukitelError as err:
+                await self._reset_connection()
+                if attempt == 1:
+                    _LOGGER.debug("read failed (%s); reconnecting and retrying once", err)
+                    continue
+                raise UpdateFailed(str(err)) from err
+
+        if (age := self._telemetry_stalled()) is not None:
+            stats = self._conn.stats() if self._conn else "no session"
+            _LOGGER.warning(
+                "%s: connected and writes are being acked, but no telemetry for %.0fs "
+                "(%s). Dropping the session to resubscribe. If this repeats, the station "
+                "is most likely unable to reach the Quectel cloud -- check for a firewall "
+                "rule blocking its internet access -- or another app holds its report stream",
+                self.dk,
+                age,
+                stats,
+            )
             await self._reset_connection()
-            raise
-        except OukitelError as err:
-            await self._reset_connection()
-            raise UpdateFailed(str(err)) from err
+            raise UpdateFailed(f"no telemetry for {age:.0f}s")
+
         await self._poll_cloud_if_due()
         return dict(self._state)
 
     # --- control ---
     async def async_set_value(self, tag: int, value: Any, *, is_bool: bool) -> None:
-        await self._ensure_connected()
+        try:
+            await self._ensure_connected()
+        except Exception:
+            # Never leave a half-set-up connection behind on a failed write; the next
+            # update would treat it as usable and read into a void.
+            await self._reset_connection()
+            raise
         assert self._conn is not None
         try:
             await self._conn.async_set(tag, value, is_bool=is_bool)
@@ -201,6 +287,18 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
         # optimistic local update; device will also echo a report
         self._state[tag] = bool(value) if is_bool else value
         self.async_set_updated_data(dict(self._state))
+
+    def connection_diagnostics(self) -> dict[str, Any]:
+        """Connection health for the diagnostics download."""
+        now = self.hass.loop.time()
+        return {
+            "connected": self._conn is not None,
+            "listener_running": self._listening(),
+            "reconnects": self._reconnects,
+            "connected_for_s": round(now - self._connected_at, 1) if self._connected_at else None,
+            "last_report_age_s": round(now - self._last_report, 1) if self._last_report else None,
+            "frames": self._conn.stats() if self._conn else None,
+        }
 
     async def async_shutdown(self) -> None:
         await super().async_shutdown()

--- a/custom_components/oukitel_power_station/diagnostics.py
+++ b/custom_components/oukitel_power_station/diagnostics.py
@@ -29,5 +29,8 @@ async def async_get_config_entry_diagnostics(
     return {
         "entry_data": async_redact_data(dict(entry.data), TO_REDACT),
         "available": coordinator.last_update_success,
+        # Connection health: a session that is up and acking writes while
+        # last_report_age_s keeps climbing means the station has stopped streaming.
+        "connection": coordinator.connection_diagnostics(),
         "telemetry": {str(tag): _jsonable(val) for tag, val in (coordinator.data or {}).items()},
     }

--- a/custom_components/oukitel_power_station/protocol.py
+++ b/custom_components/oukitel_power_station/protocol.py
@@ -294,6 +294,11 @@ class OukitelConnection:
         self._packet_id = 1000
         self._reader_task: asyncio.Task | None = None
         self._ack_waiters: dict[int, asyncio.Future] = {}
+        # Per-session frame tallies by command. A device that acks writes but never
+        # reports shows up here as tx {19,17,28729} climbing while rx holds only
+        # 28726 -- the signature we could not see at all before.
+        self._tx_counts: dict[int, int] = {}
+        self._rx_counts: dict[int, int] = {}
 
     # --- low level ---
     def _next_pid(self) -> int:
@@ -313,6 +318,7 @@ class OukitelConnection:
             await self._writer.drain()
         except OSError as err:  # reset/broken pipe: report as ours so callers reconnect
             raise OukitelError(f"send failed: {err}") from err
+        self._tx_counts[cmd] = self._tx_counts.get(cmd, 0) + 1
         return pid
 
     async def _read_frames(self) -> list[tuple[int, int, bytes]]:
@@ -402,8 +408,17 @@ class OukitelConnection:
             CMD_READ, b"".join(struct.pack(">H", t) for t in READ_TAG_IDS), encrypt=True
         )
 
+    def stats(self) -> str:
+        """Compact per-session frame tally, for debug logs and diagnostics."""
+
+        def fmt(counts: dict[int, int]) -> str:
+            return "{" + ", ".join(f"{cmd}:{n}" for cmd, n in sorted(counts.items())) + "}"
+
+        return f"tx={fmt(self._tx_counts)} rx={fmt(self._rx_counts)}"
+
     def _dispatch(self, frames: list[tuple[int, int, bytes]]) -> None:
         for _pid, cmd, payload in frames:
+            self._rx_counts[cmd] = self._rx_counts.get(cmd, 0) + 1
             # Telemetry arrives as cmd20 reports AND as the reply to a cmd17 read;
             # decode both so a polled read always refreshes state.
             if cmd in (CMD_REPORT, CMD_READ) and self._iv is not None and payload:
@@ -425,7 +440,7 @@ class OukitelConnection:
             while True:
                 await asyncio.sleep(_REARM_INTERVAL)
                 await self._rearm()
-                _LOGGER.debug("re-armed reporting (subscribe + heartbeat)")
+                _LOGGER.debug("re-armed reporting (subscribe + read + heartbeat); %s", self.stats())
         except asyncio.CancelledError:
             raise
         except Exception as err:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,83 @@
+"""Offline tests for the coordinator's telemetry-stall policy and the protocol's
+per-session frame tally. Both exist to catch a station that completes the handshake
+and acks writes while never streaming telemetry (issue #6).
+
+Run:  python3 tests/test_coordinator.py
+The stall policy is a pure function so it needs no Home Assistant instance; the
+coordinator module itself does import HA, so it is loaded only when available.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+BASE = pathlib.Path(__file__).resolve().parents[1] / "custom_components" / "oukitel_power_station"
+_pkg = types.ModuleType("ouk")
+_pkg.__path__ = [str(BASE)]
+sys.modules["ouk"] = _pkg
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(f"ouk.{name}", BASE / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[f"ouk.{name}"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+const = _load("const")
+proto = _load("protocol")
+
+_passed = 0
+
+
+def check(name: str, cond: bool) -> None:
+    global _passed
+    assert cond, f"FAIL: {name}"
+    _passed += 1
+    print(f"  ok  {name}")
+
+
+def main() -> None:
+    print("coordinator / stall-detection offline tests")
+
+    # --- per-session frame tally: the signature of a stalled device ---
+    conn = proto.OukitelConnection("127.0.0.1", "MDEyMzQ1Njc4OWFiY2RlZg==")
+    check("stats starts empty", conn.stats() == "tx={} rx={}")
+    # simulate what the log showed: writes acked (28726), no telemetry at all
+    conn._dispatch([(1, const.CMD_WRITE_ACK, b""), (2, const.CMD_WRITE_ACK, b"")])
+    check("acks counted in rx", f"{const.CMD_WRITE_ACK}:2" in conn.stats())
+    check("no report counted", f"{const.CMD_REPORT}:" not in conn.stats())
+
+    # --- stall policy ---
+    try:
+        coord = _load("coordinator")
+    except ImportError as err:  # no Home Assistant in this environment
+        print(f"  skip stall-policy checks (coordinator needs HA: {err})")
+        print(f"\nALL PASSED ({_passed} checks)")
+        return
+
+    stall = coord.stall_age
+    timeout = 150.0
+    check("nothing known -> not stalled", stall(1000.0, None, None, timeout) is None)
+    check("fresh report -> not stalled", stall(1000.0, 990.0, 500.0, timeout) is None)
+    check("old report -> stalled", stall(1000.0, 800.0, 500.0, timeout) == 200.0)
+    # a device that has never reported still gets a grace period from connect time
+    check("just connected, no report -> not stalled", stall(1000.0, None, 990.0, timeout) is None)
+    check("connected long ago, no report -> stalled", stall(1000.0, None, 700.0, timeout) == 300.0)
+    # last_report wins over connect time once one has arrived
+    check("report supersedes connect time", stall(1000.0, 990.0, 100.0, timeout) is None)
+
+    print(f"\nALL PASSED ({_passed} checks)")
+
+
+def test_offline() -> None:
+    """pytest entry point."""
+    main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Refs #6. Root cause **confirmed on the real device** — see below.

## The finding

**The station only streams LAN telemetry while it can reach the Quectel cloud.** With it firewalled off the internet (UniFi policy, destination `Internet`, both Block and Reject):

- the `p2..p5` handshake completes normally — `login OK`, result **0**, encryption on;
- every `cmd19` write is acked with `p6` — 23 of 23 over 7 minutes;
- **zero** `cmd20` reports arrive and `cmd17` reads go unanswered;
- the stall is **device-wide**, not per-session — two independent clients saw it simultaneously;
- re-writing `tag100` (0 then 3, to force a change rather than an idempotent write) does not restart it.

Removing the firewall rule restored telemetry **within seconds**, over the existing session, with no reconnect. So the device gates reporting on its cloud link while still serving the handshake and writes without one. That is device behaviour we cannot work around from the LAN side — but we can stop being silently dead about it.

## Why the integration showed nothing

Counted across the debug log: 23 acks, 22 re-arms, **0** `report=` lines, 0 `unhandled frame`, 0 decode failures. `_async_update_data` only *sends* the cmd17 read — replies are decoded by the listen task — so it returned cached state and logged:

```
Finished fetching ... data in 0.000 seconds (success: True)
```

every 60s, indefinitely, with no error. Entities went `unavailable` purely from tag-based availability over an empty state dict while the coordinator believed it was healthy. The protocol's 90s read watchdog never fired either: the acks keep the read loop fed, and it only checks that *something* arrived, not that telemetry did.

## Changes

- **Stall detection**: track the last report; after 150s without telemetry (measured from the last report, or from connect time so a fresh session gets a grace period), drop the session and raise `UpdateFailed` with a warning that names this exact cause and points at #6.
- **Require a live listener** before reusing a connection — one whose listen task never started or died reads into a void. Two paths could leave one behind: `subscribe_and_read()` failing after `_conn` was published, and `_ensure_connected()` failing inside `async_set_value()`, which had no cleanup. `_reset_connection()` now cancels the listener too, without cancelling itself when called from inside it. This is the "data stops changing but entities stay available" bug.
- **In-cycle retry** after a reset socket, so a session the device drops between polls no longer blanks every entity for a full minute — the `[Errno 104]` flap (96 transitions in ~6h).
- **Observability**: per-command frame tallies per session, logged with each re-arm (`tx={17:23, 19:23, 28729:23} rx={28726:23}` — the stall signature at a glance), plus connection health in diagnostics (`connected`, `listener_running`, `reconnects`, `connected_for_s`, `last_report_age_s`, `frames`). One diagnostics download now tells this whole story.
- **Docs**: `README.md` warns not to block the station's internet access; `REVERSE_ENGINEERING.md` records the confirmed behaviour and the evidence.

## Tests

New `tests/test_coordinator.py`, offline: the stall policy is extracted as a pure `stall_age()` needing no HA instance (6 cases — grace period, last-report-wins, both stalled directions), plus a frame-tally check reproducing the observed acks-without-reports signature. `ruff` clean, `pytest` green (16 passed).

## Scope

This makes the integration detect, report and recover. It does not make a cloud-blocked station stream — that is now documented as a device requirement rather than an integration bug.