### PR TITLE
feat: cloud-only stations (monitor a station with no LAN reach)

### DIFF
--- a/custom_components/oukitel_power_station/config_flow.py
+++ b/custom_components/oukitel_power_station/config_flow.py
@@ -12,14 +12,20 @@ from homeassistant.config_entries import (
     ConfigFlowResult,
     OptionsFlow,
 )
+from homeassistant.const import UnitOfTime
 from homeassistant.core import callback
+from homeassistant.helpers import selector
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import voluptuous as vol
 
 from .cloud import OukitelCloud, OukitelCloudAuthError, OukitelCloudError
 from .const import (
+    CLOUD_POLL_INTERVAL_MAX_S,
+    CLOUD_POLL_INTERVAL_MIN_S,
+    CLOUD_POLL_INTERVAL_S,
     CONF_AUTH_KEY,
     CONF_CLOUD_POLL,
+    CONF_CLOUD_POLL_INTERVAL,
     CONF_DK,
     CONF_EMAIL,
     CONF_ENABLE_CONTROL,
@@ -45,6 +51,20 @@ def _device_label(device: dict[str, Any]) -> str:
     name = str(device.get("deviceName") or device["deviceKey"])
     product = str(device.get("productName") or device.get("productKey") or "")
     return f"{name} ({product})" if product and product not in name else name
+
+
+def _connect_mode_schema() -> vol.Schema:
+    """Return the translated local/cloud-only connection selector."""
+    return vol.Schema(
+        {
+            vol.Required("mode", default="manual"): selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=["manual", "cloud_only"],
+                    translation_key="connect_mode",
+                )
+            )
+        }
+    )
 
 
 class OukitelConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -128,7 +148,17 @@ class OukitelConfigFlow(ConfigFlow, domain=DOMAIN):
         host = await async_discover(dk)
         if host:
             return await self._validate_and_create(host)
-        return await self.async_step_manual()
+        return await self.async_step_connect_mode()
+
+    async def async_step_connect_mode(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """The station was not discovered — manual IP, or cloud-only."""
+        if user_input is not None:
+            if user_input["mode"] == "manual":
+                return await self.async_step_manual()
+            return await self._validate_and_create(host=None)
+        return self.async_show_form(step_id="connect_mode", data_schema=_connect_mode_schema())
 
     async def async_step_manual(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         errors: dict[str, str] = {}
@@ -139,56 +169,78 @@ class OukitelConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def _validate_and_create(
-        self, host: str, errors: dict[str, str] | None = None
+        self, host: str | None, errors: dict[str, str] | None = None
     ) -> ConfigFlowResult:
         errors = errors if errors is not None else {}
         auth_key = self._device["authKey"]
-        conn = OukitelConnection(host, auth_key)
-        try:
-            await conn.connect()
-        except OukitelAuthError:
-            # Shared accounts serve a binding-time-frozen key in userDeviceList;
-            # regenerateAuthKey returns the live one (deterministic — verified
-            # live on a shared P1500: repeated calls return the same value).
+        if host is not None:
+            conn = OukitelConnection(host, auth_key)
             try:
-                cloud = await self._async_get_cloud()
-                auth_key = await cloud.regenerate_auth_key(
-                    self._device["productKey"], self._device["deviceKey"]
-                )
-            except OukitelCloudAuthError:
-                errors["base"] = "invalid_auth"
-            except OukitelCloudError:
-                errors["base"] = "cannot_connect"
-            else:
-                conn = OukitelConnection(host, auth_key)
+                await conn.connect()
+            except OukitelAuthError:
+                # Shared accounts serve a binding-time-frozen key in userDeviceList;
+                # regenerateAuthKey returns the current key used by the station.
                 try:
-                    await conn.connect()
-                except OukitelAuthError:
+                    cloud = await self._async_get_cloud()
+                    auth_key = await cloud.regenerate_auth_key(
+                        self._device["productKey"], self._device["deviceKey"]
+                    )
+                except OukitelCloudAuthError:
                     errors["base"] = "invalid_auth"
-                except OukitelError:
+                except OukitelCloudError:
                     errors["base"] = "cannot_connect"
-                finally:
-                    await conn.close()
-        except OukitelError:
-            errors["base"] = "cannot_connect"
-        finally:
-            await conn.close()
+                else:
+                    conn = OukitelConnection(host, auth_key)
+                    try:
+                        await conn.connect()
+                    except OukitelAuthError:
+                        errors["base"] = "invalid_auth"
+                    except OukitelError:
+                        errors["base"] = "cannot_connect"
+                    finally:
+                        await conn.close()
+            except OukitelError:
+                errors["base"] = "cannot_connect"
+            finally:
+                await conn.close()
         if errors:
             return self.async_show_form(
                 step_id="manual",
                 data_schema=vol.Schema({vol.Required(CONF_HOST): str}),
                 errors=errors,
             )
-        # Capture the product thing-model so the runtime never needs the cloud
-        # to know the model's entities (bundled TSL is the offline fallback).
+
+        # Capture the thing-model for both connection modes. Cloud-only setup
+        # additionally reads the shadow once to validate device access.
         manifest: dict[str, Any] = {}
         try:
             cloud = await self._async_get_cloud()
             tsl = await cloud.get_tsl(self._device["productKey"])
+            vendor_manifest = build_manifest(tsl)
+            if not vendor_manifest.tags:
+                raise OukitelCloudError("productTSL returned no properties")
+            if host is None:
+                await cloud.get_business_attributes(
+                    self._device["productKey"], self._device["deviceKey"]
+                )
+        except OukitelCloudAuthError as err:
+            if host is None:
+                return self.async_show_form(
+                    step_id="connect_mode",
+                    data_schema=_connect_mode_schema(),
+                    errors={"base": "invalid_auth"},
+                )
+            _LOGGER.debug("productTSL fetch failed (bundled fallback): %s", err)
         except OukitelCloudError as err:
+            if host is None:
+                return self.async_show_form(
+                    step_id="connect_mode",
+                    data_schema=_connect_mode_schema(),
+                    errors={"base": "cannot_connect"},
+                )
             _LOGGER.debug("productTSL fetch failed (bundled fallback): %s", err)
         else:
-            manifest = build_manifest(tsl).to_dict()
+            manifest = vendor_manifest.to_dict()
         return self.async_create_entry(
             title=self._device.get("deviceName") or self._device["deviceKey"],
             data={
@@ -244,18 +296,38 @@ class OukitelConfigFlow(ConfigFlow, domain=DOMAIN):
 
 
 class OukitelOptionsFlow(OptionsFlow):
-    """Options: opt in to cloud-only values; opt in to local control."""
+    """Options: cloud poll + control (local stations) / poll interval (cloud-only)."""
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
         if user_input is not None:
             return self.async_create_entry(data=user_input)
         options = self.config_entry.options
-        schema = vol.Schema(
-            {
-                vol.Required(CONF_CLOUD_POLL, default=options.get(CONF_CLOUD_POLL, False)): bool,
-                vol.Required(
-                    CONF_ENABLE_CONTROL, default=options.get(CONF_ENABLE_CONTROL, False)
-                ): bool,
-            }
-        )
+        if self.config_entry.data.get(CONF_HOST):
+            schema = vol.Schema(
+                {
+                    vol.Required(
+                        CONF_CLOUD_POLL, default=options.get(CONF_CLOUD_POLL, False)
+                    ): bool,
+                    vol.Required(
+                        CONF_ENABLE_CONTROL, default=options.get(CONF_ENABLE_CONTROL, False)
+                    ): bool,
+                }
+            )
+        else:
+            schema = vol.Schema(
+                {
+                    vol.Required(
+                        CONF_CLOUD_POLL_INTERVAL,
+                        default=options.get(CONF_CLOUD_POLL_INTERVAL, CLOUD_POLL_INTERVAL_S),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=CLOUD_POLL_INTERVAL_MIN_S,
+                            max=CLOUD_POLL_INTERVAL_MAX_S,
+                            step=60,
+                            mode=selector.NumberSelectorMode.BOX,
+                            unit_of_measurement=UnitOfTime.SECONDS,
+                        )
+                    )
+                }
+            )
         return self.async_show_form(step_id="init", data_schema=schema)

--- a/custom_components/oukitel_power_station/const.py
+++ b/custom_components/oukitel_power_station/const.py
@@ -76,15 +76,19 @@ CONF_PASSWORD: Final = "password"
 CONF_PK: Final = "pk"  # productKey
 CONF_DK: Final = "dk"  # deviceKey (== MAC, lowercase, no separators)
 CONF_AUTH_KEY: Final = "auth_key"
-CONF_HOST: Final = "host"  # station LAN IP
+CONF_HOST: Final = "host"  # station LAN IP (absent/None = cloud-only station)
 CONF_NAME: Final = "name"
 CONF_MANIFEST: Final = "manifest"  # product manifest snapshot taken at setup
 CONF_CLOUD_POLL: Final = "cloud_poll"  # opt-in: fetch cloud-only values (temp/voltage)
 CONF_ENABLE_CONTROL: Final = "enable_control"  # opt-in: expose switches/selects/number
+CONF_CLOUD_POLL_INTERVAL: Final = "cloud_poll_interval"  # seconds (cloud-only mode)
 
 # Tags the device never sends over the LAN; only available from the cloud snapshot.
 CLOUD_ONLY_TAGS: Final = (14, 28)  # temperature, output voltage
 CLOUD_POLL_INTERVAL_S: Final = 300  # how often to poll the cloud when enabled
+# Bounds for the cloud-only mode poll interval (options flow).
+CLOUD_POLL_INTERVAL_MIN_S: Final = 60
+CLOUD_POLL_INTERVAL_MAX_S: Final = 3600
 
 # ---- enum value maps (TSL) ----
 FREQUENCY_OPTIONS: Final = {0: "50 Hz", 1: "60 Hz"}

--- a/custom_components/oukitel_power_station/coordinator.py
+++ b/custom_components/oukitel_power_station/coordinator.py
@@ -16,9 +16,12 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .cloud import OukitelCloud, OukitelCloudAuthError, OukitelCloudError
 from .const import (
     CLOUD_ONLY_TAGS,
+    CLOUD_POLL_INTERVAL_MAX_S,
+    CLOUD_POLL_INTERVAL_MIN_S,
     CLOUD_POLL_INTERVAL_S,
     CONF_AUTH_KEY,
     CONF_CLOUD_POLL,
+    CONF_CLOUD_POLL_INTERVAL,
     CONF_DK,
     CONF_EMAIL,
     CONF_HOST,
@@ -88,24 +91,32 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
         self._reconnects = 0
         self.options = dict(entry.options)
         self._manifest = manifest
+        if not self.local_capable:
+            try:
+                interval = float(entry.options.get(CONF_CLOUD_POLL_INTERVAL, CLOUD_POLL_INTERVAL_S))
+            except (TypeError, ValueError):
+                interval = CLOUD_POLL_INTERVAL_S
+            interval = min(max(interval, CLOUD_POLL_INTERVAL_MIN_S), CLOUD_POLL_INTERVAL_MAX_S)
+            self.update_interval = timedelta(seconds=interval)
 
     @property
     def dk(self) -> str:
         return self.config_entry.data[CONF_DK]
 
     @property
-    def host(self) -> str:
-        return self.config_entry.data[CONF_HOST]
+    def host(self) -> str | None:
+        """The last known LAN IP of the station (None = cloud-only)."""
+        return self.config_entry.data.get(CONF_HOST)
+
+    @property
+    def local_capable(self) -> bool:
+        """True when this entry has a LAN address and can do local control."""
+        return bool(self.host)
 
     @property
     def manifest(self) -> ProductManifest:
         """The product manifest (TSL-derived capability model)."""
         return self._manifest
-
-    @property
-    def local_capable(self) -> bool:
-        """Return whether this entry has a writable local connection."""
-        return True
 
     # --- connection lifecycle ---
     def _handle_report(self, report: dict[int, Any]) -> None:
@@ -129,6 +140,8 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
             _LOGGER.debug("connection has no live listener; dropping it")
             await self._reset_connection()
         host = self.host
+        if not host:
+            return  # cloud-only station: never opens a local session
         _LOGGER.debug("(re)connecting to %s at %s", self.dk, host)
         conn = OukitelConnection(
             host,
@@ -265,7 +278,44 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
         """Age of the last report if the device has gone quiet, else None."""
         return stall_age(self.hass.loop.time(), self._last_report, self._connected_at)
 
+    async def _async_login_cloud(self) -> OukitelCloud:
+        """Create a cloud client, mapping only rejected credentials to reauth."""
+        data = self.config_entry.data
+        cloud = OukitelCloud(async_get_clientsession(self.hass), data[CONF_REGION])
+        try:
+            await cloud.login(data[CONF_EMAIL], data[CONF_PASSWORD])
+        except OukitelCloudAuthError as err:
+            raise ConfigEntryAuthFailed(str(err)) from err
+        except OukitelCloudError as err:
+            raise UpdateFailed(f"cloud login failed: {err}") from err
+        self._cloud = cloud
+        return cloud
+
+    async def _update_cloud_only(self) -> dict[int, Any]:
+        """Cloud-only mode: serve everything from the cloud shadow."""
+        data = self.config_entry.data
+        cloud = self._cloud or await self._async_login_cloud()
+        try:
+            attrs = await cloud.get_business_attributes(data[CONF_PK], self.dk)
+        except OukitelCloudAuthError:
+            self._cloud = None
+            cloud = await self._async_login_cloud()
+            try:
+                attrs = await cloud.get_business_attributes(data[CONF_PK], self.dk)
+            except OukitelCloudError as err:
+                if isinstance(err, OukitelCloudAuthError):
+                    self._cloud = None
+                raise UpdateFailed(f"cloud poll failed after re-login: {err}") from err
+        except OukitelCloudError as err:
+            raise UpdateFailed(f"cloud poll failed: {err}") from err
+        if attrs:
+            self._state.update(attrs)
+        return dict(self._state)
+
     async def _async_update_data(self) -> dict[int, Any]:
+        if not self.local_capable:
+            return await self._update_cloud_only()
+
         # Two attempts: a session the device reset between polls fails on the first
         # send, and reconnecting takes well under a second. Retrying here keeps that
         # invisible instead of blanking every entity until the next cycle.
@@ -307,6 +357,10 @@ class OukitelCoordinator(DataUpdateCoordinator[dict[int, Any]]):
 
     # --- control ---
     async def async_set_value(self, tag: int, value: Any, *, is_bool: bool) -> None:
+        if not self.local_capable:
+            raise OukitelError(
+                "no local link to the station — control unavailable (cloud shadow is read-only)"
+            )
         try:
             await self._ensure_connected()
         except Exception:

--- a/custom_components/oukitel_power_station/strings.json
+++ b/custom_components/oukitel_power_station/strings.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Oukitel cloud login",
-        "description": "Sign in with your WonderFree / Oukitel account. Used once to fetch the device key; control is local afterwards.",
+        "description": "Sign in with your WonderFree / Oukitel account. Credentials are used to fetch the device key and product information; runtime can use a local connection or read-only cloud monitoring.",
         "data": {
           "region": "Region",
           "email": "Email",
@@ -29,6 +29,16 @@
         "data": {
           "password": "Password"
         }
+      },
+      "connect_mode": {
+        "title": "Connection mode",
+        "description": "The station was not found by UDP discovery (it and Home Assistant must be on the same network). Enter its IP manually, or monitor it cloud-only: data via the cloud shadow, no local control.",
+        "data": {
+          "mode": "Connection mode"
+        },
+        "data_description": {
+          "mode": "Choose whether to enter a local IP address or use read-only cloud monitoring."
+        }
       }
     },
     "error": {
@@ -47,11 +57,13 @@
         "title": "Options",
         "data": {
           "cloud_poll": "Fetch temperature & voltage from the cloud",
-          "enable_control": "Enable device control (output switches, voltage/frequency, charge limit)"
+          "enable_control": "Enable device control (output switches, voltage/frequency, charge limit)",
+          "cloud_poll_interval": "Cloud poll interval (seconds)"
         },
         "data_description": {
           "cloud_poll": "This device does not send temperature or output voltage over the local network. Enable this to poll the Quectel cloud every few minutes (using your stored credentials) to fill them in. Off by default to keep operation fully local.",
-          "enable_control": "New entries default to off because this is a UPS. Existing entries keep control enabled. When on, exposes the output switches, output voltage/frequency and the AC charge limit as writable entities over the local link."
+          "enable_control": "New entries default to off because this is a UPS. Existing entries keep control enabled. When on, exposes the output switches, output voltage/frequency and the AC charge limit as writable entities over the local link.",
+          "cloud_poll_interval": "How often to refresh data from the cloud shadow (60-3600 s). Data freshness is bounded by how often the station itself reports to the cloud."
         }
       }
     }
@@ -98,6 +110,14 @@
     },
     "button": {
       "reload": { "name": "Reload" }
+    }
+  },
+  "selector": {
+    "connect_mode": {
+      "options": {
+        "manual": "Enter a local IP address",
+        "cloud_only": "Cloud-only monitoring (read-only)"
+      }
     }
   }
 }

--- a/custom_components/oukitel_power_station/translations/en.json
+++ b/custom_components/oukitel_power_station/translations/en.json
@@ -3,7 +3,7 @@
     "step": {
       "user": {
         "title": "Oukitel cloud login",
-        "description": "Sign in with your WonderFree / Oukitel account. Used once to fetch the device key; control is local afterwards.",
+        "description": "Sign in with your WonderFree / Oukitel account. Credentials are used to fetch the device key and product information; runtime can use a local connection or read-only cloud monitoring.",
         "data": {
           "region": "Region",
           "email": "Email",
@@ -29,6 +29,16 @@
         "data": {
           "password": "Password"
         }
+      },
+      "connect_mode": {
+        "title": "Connection mode",
+        "description": "The station was not found by UDP discovery (it and Home Assistant must be on the same network). Enter its IP manually, or monitor it cloud-only: data via the cloud shadow, no local control.",
+        "data": {
+          "mode": "Connection mode"
+        },
+        "data_description": {
+          "mode": "Choose whether to enter a local IP address or use read-only cloud monitoring."
+        }
       }
     },
     "error": {
@@ -47,11 +57,13 @@
         "title": "Options",
         "data": {
           "cloud_poll": "Fetch temperature & voltage from the cloud",
-          "enable_control": "Enable device control (output switches, voltage/frequency, charge limit)"
+          "enable_control": "Enable device control (output switches, voltage/frequency, charge limit)",
+          "cloud_poll_interval": "Cloud poll interval (seconds)"
         },
         "data_description": {
           "cloud_poll": "This device does not send temperature or output voltage over the local network. Enable this to poll the Quectel cloud every few minutes (using your stored credentials) to fill them in. Off by default to keep operation fully local.",
-          "enable_control": "New entries default to off because this is a UPS. Existing entries keep control enabled. When on, exposes the output switches, output voltage/frequency and the AC charge limit as writable entities over the local link."
+          "enable_control": "New entries default to off because this is a UPS. Existing entries keep control enabled. When on, exposes the output switches, output voltage/frequency and the AC charge limit as writable entities over the local link.",
+          "cloud_poll_interval": "How often to refresh data from the cloud shadow (60-3600 s). Data freshness is bounded by how often the station itself reports to the cloud."
         }
       }
     }
@@ -98,6 +110,14 @@
     },
     "button": {
       "reload": { "name": "Reload" }
+    }
+  },
+  "selector": {
+    "connect_mode": {
+      "options": {
+        "manual": "Enter a local IP address",
+        "cloud_only": "Cloud-only monitoring (read-only)"
+      }
     }
   }
 }

--- a/custom_components/oukitel_power_station/translations/pl.json
+++ b/custom_components/oukitel_power_station/translations/pl.json
@@ -29,6 +29,16 @@
         "data": {
           "password": "Hasło"
         }
+      },
+      "connect_mode": {
+        "title": "Tryb połączenia",
+        "description": "Stacji nie znaleziono przez UDP (HA i stacja muszą być w tej samej sieci). Podaj IP ręcznie lub monitoruj tylko przez chmurę: dane z cienia chmurowego, bez sterowania lokalnego.",
+        "data": {
+          "mode": "Tryb połączenia"
+        },
+        "data_description": {
+          "mode": "Wybierz, czy podać lokalny adres IP, czy używać monitorowania tylko przez chmurę (tylko do odczytu)."
+        }
       }
     },
     "error": {
@@ -47,11 +57,13 @@
         "title": "Opcje",
         "data": {
           "cloud_poll": "Pobieraj temperaturę i napięcie z chmury",
-          "enable_control": "Włącz sterowanie urządzeniem (przełączniki wyjść, napięcie/częstotliwość, limit ładowania)"
+          "enable_control": "Włącz sterowanie urządzeniem (przełączniki wyjść, napięcie/częstotliwość, limit ładowania)",
+          "cloud_poll_interval": "Interwał odpytywania chmury (sekundy)"
         },
         "data_description": {
           "cloud_poll": "To urządzenie nie wysyła temperatury ani napięcia wyjściowego po sieci lokalnej. Włącz, aby odpytywać chmurę Quectel co kilka minut (zapisanymi poświadczeniami) i uzupełniać te wartości. Domyślnie wyłączone, aby działanie było w pełni lokalne.",
-          "enable_control": "Nowe wpisy domyślnie wyłączone (to UPS). Istniejące wpisy zachowują sterowanie włączone. Po włączeniu udostępnia przełączniki wyjść, napięcie/częstotliwość i limit ładowania AC jako encje zapisywalne przez połączenie lokalne."
+          "enable_control": "Nowe wpisy domyślnie wyłączone (to UPS). Istniejące wpisy zachowują sterowanie włączone. Po włączeniu udostępnia przełączniki wyjść, napięcie/częstotliwość i limit ładowania AC jako encje zapisywalne przez połączenie lokalne.",
+          "cloud_poll_interval": "Jak często odświeżać dane z cienia chmurowego (60-3600 s). Świeżość danych jest ograniczona tym, jak często stacja sama raportuje do chmury."
         }
       }
     }
@@ -98,6 +110,14 @@
     },
     "button": {
       "reload": { "name": "Przeładuj" }
+    }
+  },
+  "selector": {
+    "connect_mode": {
+      "options": {
+        "manual": "Podaj lokalny adres IP",
+        "cloud_only": "Monitorowanie tylko przez chmurę (tylko do odczytu)"
+      }
     }
   }
 }


### PR DESCRIPTION
**Depends on #17 + #18 (manifest layer + P1500 support).** Diff for review: [compare/pr/3-p1500-support...pr/5a-cloud-only](https://github.com/rzemykers/ha-oukitel-powerstation/compare/pr/3-p1500-support...pr/5a-cloud-only)

## What
A station that **cannot be reached on the LAN** (different network, remote site, discovery blocked) can now be added as **cloud-only**:

- Config flow: when discovery fails, the user chooses **manual IP** (as before) or **cloud-only** (new `connect_mode` step). Cloud-only stores `host=None` — no local handshake by construction.
- Coordinator: an entry without a host is served entirely from the **cloud shadow** (`getDeviceBusinessAttributes`) on a **configurable interval** (default 300 s, 60–3600 s in options, which show the interval only for cloud-only entries).
- **Writes are refused with a clear error** ("no local link — control unavailable, cloud shadow is read-only") and the local session is never opened.
- Multiple stations mix freely under one account: one config entry per station — e.g. the garage unit local-push, the remote cabin unit cloud-only.

Also included: the `regenerateAuthKey` fallback for the authKey refresh (from #16) — cloud-only entries still need a valid authKey refresh path, and shared accounts serve a binding-time-frozen list key.

## Limits (documented honestly)
- The shadow exposes only scalar/enum tags — struct port powers (per-port USB/Type-C/AC/DC) stay `unavailable` on cloud-only stations (the integration does not fabricate values).
- Data freshness is bounded by how often the station itself reports to the cloud (standard reporting rate); polling faster than that gains nothing.
- Cloud-only = read-only monitoring. For control you need the local link.

## How tested
- 14/14 offline tests pass; ruff clean.
- The same shadow-poll path has run on my production HA (P1500) as the **cloud-fallback** for local-link outages — including one live failover after a restart burst this week (entities stayed alive, transport recovered to local).
- ⚠️ The end-to-end "add a cloud-only entry" flow needs a second physical station to soak-test properly — flagged for post-merge community validation; the failure modes (auth/cloud outage) map to `ConfigEntryAuthFailed`/`UpdateFailed` and retry like any other entry.

Translations: `strings.json` + `en.json` updated (`connect_mode` step, interval option).