### PR TITLE
fix: correct the p11uve model name to P1500E Plus

### DIFF
--- a/custom_components/oukitel_power_station/product.py
+++ b/custom_components/oukitel_power_station/product.py
@@ -1,7 +1,7 @@
 """Product capabilities exposed by a WonderFree power station.
 
 The manifest is the ONLY place model knowledge lives. Platforms never ask
-"is this a P1500?" — they ask the manifest "does this tag (or struct subtag)
+"is this a P1500E Plus?" — they ask the manifest "does this tag (or struct subtag)
 exist on this product?" and the coordinator asks it for the read list and
 the cloud shadow key map. Adding a new model = adding its productTSL
 snapshot under ``tsl/`` (and, when needed, a curated override entry).
@@ -18,7 +18,7 @@ Sources of truth, in resolver priority order:
 
 Curated overrides (``KNOWN_PRODUCTS``) are applied after resolving a source.
 They record verified firmware behaviour the TSL itself does not express —
-e.g. the P1500 pins remain_time (2) and
+e.g. the P1500E Plus pins remain_time (2) and
 remain_charging_time (3) to 5940, so those sensors are excluded there
 (verified live 2026-09-06) while the P2001E Plus reports them correctly.
 
@@ -45,7 +45,7 @@ _TSL_DIR = Path(__file__).parent / "tsl"
 # productName from userDeviceList wins when it is available.
 KNOWN_PRODUCTS: dict[str, dict[str, Any]] = {
     "p11uve": {
-        "model": "P1500",
+        "model": "P1500E Plus",
         # Pinned to 5940 by this firmware (verified live) — useless sensors.
         "excluded_tags": (2, 3),
     },

--- a/tests/test_tsl.py
+++ b/tests/test_tsl.py
@@ -97,10 +97,10 @@ def test_parse_scalars_and_enums(p1500_tsl):
 def test_parse_structs(p1500_tsl, p2001e_tsl):
     p1500 = parse_tsl(p1500_tsl)["tags"]
     p2001e = parse_tsl(p2001e_tsl)["tags"]
-    # P1500: 2 Type-C ports; P2001E Plus: 4 (verified TSL diff).
+    # P1500E Plus: 2 Type-C ports; P2001E Plus: 4 (verified TSL diff).
     assert sorted(p1500[TAG_TYPEC_STRUCT]["struct"]) == [2, 5]
     assert sorted(p2001e[TAG_TYPEC_STRUCT]["struct"]) == [2, 5, 6, 7]
-    # P2001E Plus structs mirror the output switches as subtag 1; P1500 not.
+    # P2001E Plus structs mirror the output switches as subtag 1; P1500E Plus not.
     assert 1 in p2001e[TAG_AC_STRUCT]["struct"]
     assert 1 not in p1500[TAG_AC_STRUCT]["struct"]
     assert p1500[TAG_AC_STRUCT]["struct"][2]["unit"] == "W"
@@ -139,7 +139,7 @@ def test_build_manifest_known_products(p1500_tsl, p2001e_tsl):
     m1500 = resolve_manifest("p11uve", cloud_tsl=p1500_tsl)
     assert m1500 is not None
     assert m1500.product_key == "p11uve"
-    assert m1500.model == "P1500"
+    assert m1500.model == "P1500E Plus"
     assert m1500.excluded_tags == (TAG_REMAIN_TIME, TAG_REMAIN_CHARGING_TIME)
 
     m2001e = resolve_manifest("p11wN7", cloud_tsl=p2001e_tsl)
@@ -162,10 +162,10 @@ def test_manifest_gating(p1500_tsl, p2001e_tsl):
     m2001e = resolve_manifest("p11wN7", cloud_tsl=p2001e_tsl)
     assert m1500 is not None
     assert m2001e is not None
-    # P1500 has LED, no USB switch; P2001E Plus has USB switch, no LED.
+    # P1500E Plus has LED, no USB switch; P2001E Plus has USB switch, no LED.
     assert m1500.has_tag(TAG_LED_STATUS) and not m1500.has_tag(TAG_USB_SWITCH)
     assert m2001e.has_tag(TAG_USB_SWITCH) and not m2001e.has_tag(TAG_LED_STATUS)
-    # curated exclude: the pinned time sensors vanish on the P1500 only.
+    # curated exclude: the pinned time sensors vanish on the P1500E Plus only.
     assert not m1500.has_tag(TAG_REMAIN_TIME)
     assert not m1500.has_tag(TAG_REMAIN_CHARGING_TIME)
     assert m2001e.has_tag(TAG_REMAIN_TIME)
@@ -219,12 +219,12 @@ def test_resolve_manifest_priority(p1500_tsl):
     resolved = resolve_manifest("p11uve", snapshot=fake)
     assert resolved is not None
     assert resolved.tsl_version == "snapshotted"
-    assert resolved.model == "P1500"
+    assert resolved.model == "P1500E Plus"
     assert resolved.excluded_tags == (TAG_REMAIN_TIME, TAG_REMAIN_CHARGING_TIME)
     # bundled as fallback
     resolved = resolve_manifest("p11uve")
     assert resolved is not None
-    assert resolved.model == "P1500"
+    assert resolved.model == "P1500E Plus"
     assert resolved.tags == bundled.tags
     # cloud data as the last resort for an unknown product key
     resolved = resolve_manifest("pkNew", cloud_tsl=p1500_tsl)


### PR DESCRIPTION
`KNOWN_PRODUCTS` labels `p11uve` as **P1500**, and that string is what the device registry shows as the model. The hardware is the **P1500E Plus** — Oukitel markets it as the "P1500 Plus" (SKU `EU-P1500-Plus-Gray`, 1800 W / 1536 Wh). Confirmed by the owner of the unit the `p11uve` manifest entry was originally added from.

### What changes
- `KNOWN_PRODUCTS["p11uve"]["model"]`: `P1500` → `P1500E Plus`, plus the two references in the module docstring.
- The three assertions and four comments in `tests/test_tsl.py` that pin the old string.

### What does not change
Display only. Manifest keys, the bundled TSL snapshot and the excluded tags are untouched, so entity sets, unique ids and behaviour stay exactly as they are; existing entries pick the new model string up on their next reload.

`pytest` 15/15 and `ruff check` / `ruff format --check` clean.

A README refresh is in a separate PR so this stays reviewable on its own.